### PR TITLE
feat: implement provider strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+async-trait = "0.1.57"
 warp = "0.3"
 hyper = "0.14.4"
 hyper-tls = "0.5.0"

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,7 +1,16 @@
 use hyper::{Body, Response, StatusCode};
+use serde::Deserialize;
 
 pub mod health;
 pub mod proxy;
+
+#[derive(Deserialize)]
+pub struct RPCQueryParams {
+    #[serde(rename = "chainId")]
+    chain_id: String,
+    #[serde(rename = "projectId")]
+    project_id: String,
+}
 
 #[derive(serde::Serialize)]
 pub struct ErrorReason {

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -1,0 +1,42 @@
+use super::{RPCProvider, RPCQueryParams};
+use async_trait::async_trait;
+use hyper::Error;
+use hyper::{client::HttpConnector, Body, Client, Response};
+use hyper_tls::HttpsConnector;
+
+#[derive(Clone)]
+pub struct InfuraProvider {
+    pub client: Client<HttpsConnector<HttpConnector>>,
+    pub infura_project_id: String,
+}
+
+#[async_trait]
+impl RPCProvider for InfuraProvider {
+    async fn proxy(
+        &self,
+        method: hyper::http::Method,
+        path: warp::path::FullPath,
+        _query_params: RPCQueryParams,
+        _headers: hyper::http::HeaderMap,
+        body: hyper::body::Bytes,
+    ) -> Result<Response<Body>, Error> {
+        let mut req = {
+            let full_path = path.as_str().to_string();
+            let hyper_request = hyper::http::Request::builder()
+                .method(method)
+                .uri(full_path)
+                .header("Content-Type", "application/json")
+                .body(hyper::body::Body::from(body))
+                .expect("Request::builder() failed");
+            hyper_request
+        };
+
+        *req.uri_mut() = format!("https://mainnet.infura.io/v3/{}", self.infura_project_id)
+            .parse()
+            .expect("Failed to parse the uri");
+
+        // TODO: map the response error codes properly
+        // e.g. HTTP401 from target should map to HTTP500
+        self.client.request(req).await
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,0 +1,36 @@
+mod infura;
+
+use crate::handlers::RPCQueryParams;
+use async_trait::async_trait;
+use hyper::Body;
+use hyper::Error;
+use hyper::Response;
+pub use infura::InfuraProvider;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Default, Clone)]
+pub struct ProviderRepository {
+    map: HashMap<String, Arc<dyn RPCProvider>>,
+}
+
+impl ProviderRepository {
+    pub fn get_provider(&self, chain: &str) -> Option<&Arc<dyn RPCProvider>> {
+        self.map.get(chain)
+    }
+    pub fn add_provider(&mut self, chain: String, provider: Arc<dyn RPCProvider>) {
+        self.map.insert(chain, provider);
+    }
+}
+
+#[async_trait]
+pub trait RPCProvider: Send + Sync {
+    async fn proxy(
+        &self,
+        method: hyper::http::Method,
+        xpath: warp::path::FullPath,
+        query_params: RPCQueryParams,
+        headers: hyper::http::HeaderMap,
+        body: hyper::body::Bytes,
+    ) -> Result<Response<Body>, Error>;
+}


### PR DESCRIPTION
Implements a basic strategy pattern with an Infura strategy for Ethereum to support multiple RPC providers depending on the desired chain in the future.

# Testing
Manually tested

