### PR TITLE
feat: supports chains other than mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rpc-proxy
 
-`cargo run` to run and then `curl -v localhost:3000/health`
+`cargo run` to run and then `curl -v localhost:3000/health` or `curl -X POST -H "Content-Type:application/json" "http://localhost:3000/v1?chainId=eip155:5&projectId=someid" -d '{"id":"1660887896683","jsonrpc":"2.0","method":"eth_chainId","params":[]}'`
 
 ### Docker
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,6 @@
 use crate::error;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
@@ -10,6 +11,8 @@ pub struct Config {
     #[serde(default = "default_log_level")]
     pub log_level: String,
     pub infura_project_id: String,
+    #[serde(default = "default_infura_supported_chains")]
+    pub infura_supported_chains: HashMap<String, String>,
 }
 
 fn default_port() -> u16 {
@@ -22,6 +25,16 @@ fn default_host() -> String {
 
 fn default_log_level() -> String {
     "WARN".to_string()
+}
+
+fn default_infura_supported_chains() -> HashMap<String, String> {
+    HashMap::from([
+        ("eip155:1".into(), "mainnet".into()),
+        ("eip155:3".into(), "ropsten".into()),
+        ("eip155:42".into(), "kovan".into()),
+        ("eip155:4".into(), "rinkeby".into()),
+        ("eip155:5".into(), "goerli".into()),
+    ])
 }
 
 pub fn get_config() -> error::Result<Config> {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -7,9 +7,9 @@ pub mod proxy;
 #[derive(Deserialize)]
 pub struct RPCQueryParams {
     #[serde(rename = "chainId")]
-    chain_id: String,
+    pub chain_id: String,
     #[serde(rename = "projectId")]
-    project_id: String,
+    pub project_id: String,
 }
 
 #[derive(serde::Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ async fn main() -> error::Result<()> {
 
     let state_arc = Arc::new(state);
     let infura_project_id = state_arc.config.infura_project_id.clone();
+    let infura_supported_chains = state_arc.config.infura_supported_chains.clone();
     let state_filter = warp::any().map(move || state_arc.clone());
 
     let health = warp::get()
@@ -46,6 +47,7 @@ async fn main() -> error::Result<()> {
     let infura_provider = InfuraProvider {
         client: forward_proxy_client,
         infura_project_id,
+        infura_supported_chains,
     };
     providers.add_provider("eth".into(), Arc::new(infura_provider));
     let provider_filter = warp::any().map(move || providers.clone());

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -3,11 +3,13 @@ use async_trait::async_trait;
 use hyper::Error;
 use hyper::{client::HttpConnector, Body, Client, Response};
 use hyper_tls::HttpsConnector;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct InfuraProvider {
     pub client: Client<HttpsConnector<HttpConnector>>,
     pub infura_project_id: String,
+    pub infura_supported_chains: HashMap<String, String>,
 }
 
 #[async_trait]
@@ -16,7 +18,7 @@ impl RPCProvider for InfuraProvider {
         &self,
         method: hyper::http::Method,
         path: warp::path::FullPath,
-        _query_params: RPCQueryParams,
+        query_params: RPCQueryParams,
         _headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> Result<Response<Body>, Error> {
@@ -28,13 +30,22 @@ impl RPCProvider for InfuraProvider {
             .body(hyper::body::Body::from(body))
             .expect("Request::builder() failed");
 
+        let chain = self
+            .infura_supported_chains
+            .get(&query_params.chain_id.to_lowercase())
+            .expect("Chain not found despite previous validation");
+
         *hyper_request.uri_mut() =
-            format!("https://mainnet.infura.io/v3/{}", self.infura_project_id)
+            format!("https://{}.infura.io/v3/{}", chain, self.infura_project_id)
                 .parse()
                 .expect("Failed to parse the uri");
 
         // TODO: map the response error codes properly
         // e.g. HTTP401 from target should map to HTTP500
         self.client.request(hyper_request).await
+    }
+
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool {
+        self.infura_supported_chains.contains_key(chain_id)
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -33,4 +33,6 @@ pub trait RPCProvider: Send + Sync {
         headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> Result<Response<Body>, Error>;
+
+    fn supports_caip_chainid(&self, chain_id: &str) -> bool;
 }


### PR DESCRIPTION
Supports all chains that Infura currently supports expected to be specified as CAIP2 e.g. eip155:1.

# Testing

`curl -vvv -X POST -H "Content-Type:application/json" "http://localhost:3000/v1?chainId=eip155:5&projectId=someid" -d '{"id":"1660887896683","jsonrpc":"2.0","method":"eth_chainId","params":[]}'`