### PR TITLE
feat: install metrics and export via prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +308,16 @@ checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
 ]
 
 [[package]]
@@ -398,6 +428,17 @@ name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-sink"
@@ -902,6 +943,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9328977e479cebe12ce0d3fcecdaea4721d234895a9440c5b5dfd113f0594ac6"
+dependencies = [
+ "opentelemetry",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1110,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cface98dfa6d645ea4c789839f176e4b072265d085bfcc48eaa8d137f58d3c39"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,8 +1204,12 @@ dependencies = [
  "envy",
  "hyper",
  "hyper-tls",
+ "opentelemetry",
+ "opentelemetry-prometheus",
+ "prometheus",
  "serde",
  "serde_json",
+ "tap",
  "tokio",
  "tracing",
  "warp",
@@ -1301,6 +1401,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.57"
 warp = "0.3"
 hyper = "0.14.4"
 hyper-tls = "0.5.0"
+tap = "1.0"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -20,9 +21,12 @@ serde_json = "1.0"
 dotenv = "0.15.0"
 envy = "0.4"
 
-tracing = "0.1"
-
 build-info = "0.0.27"
+
+prometheus-core = { package = "prometheus", version = "0.13" }
+opentelemetry = { version = "0.17.0", features = ["trace", "metrics", "rt-tokio"] }
+opentelemetry-prometheus = "0.10.0"
+tracing = "0.1"
 
 [build-dependencies]
 build-info-build = "0.0.27"

--- a/src/handlers/metrics.rs
+++ b/src/handlers/metrics.rs
@@ -21,8 +21,7 @@ pub async fn handler(state: Arc<State>) -> Result<impl warp::Reply, warp::Reject
             let data = exporter.registry().gather();
             match TextEncoder::new().encode_to_string(&data) {
                 Ok(content) => {
-                    let response =
-                        warp::reply::with_status(content, http::StatusCode::OK);
+                    let response = warp::reply::with_status(content, http::StatusCode::OK);
 
                     Ok(response)
                 }

--- a/src/handlers/metrics.rs
+++ b/src/handlers/metrics.rs
@@ -1,0 +1,41 @@
+use crate::State;
+use prometheus_core::TextEncoder;
+use std::sync::Arc;
+use tracing::error;
+use warp::http;
+
+pub async fn handler(state: Arc<State>) -> Result<impl warp::Reply, warp::Rejection> {
+    match &state.exporter {
+        None => {
+            let response = warp::reply::with_status(
+                format!(
+                    "No metrics installed v{}",
+                    state.build_info.crate_info.version
+                ),
+                http::StatusCode::OK,
+            );
+
+            Ok(response)
+        }
+        Some(exporter) => {
+            let data = exporter.registry().gather();
+            match TextEncoder::new().encode_to_string(&data) {
+                Ok(content) => {
+                    let response =
+                        warp::reply::with_status(format!("{}", content), http::StatusCode::OK);
+
+                    Ok(response)
+                }
+                Err(e) => {
+                    error!(?e, "Failed to parse metrics");
+                    let response = warp::reply::with_status(
+                        "Failed to get metrics".into(),
+                        http::StatusCode::INTERNAL_SERVER_ERROR,
+                    );
+
+                    Ok(response)
+                }
+            }
+        }
+    }
+}

--- a/src/handlers/metrics.rs
+++ b/src/handlers/metrics.rs
@@ -5,36 +5,21 @@ use tracing::error;
 use warp::http;
 
 pub async fn handler(state: Arc<State>) -> Result<impl warp::Reply, warp::Rejection> {
-    match &state.exporter {
-        None => {
-            let response = warp::reply::with_status(
-                format!(
-                    "No metrics installed v{}",
-                    state.build_info.crate_info.version
-                ),
-                http::StatusCode::OK,
-            );
+    let data = state.exporter.registry().gather();
+    match TextEncoder::new().encode_to_string(&data) {
+        Ok(content) => {
+            let response = warp::reply::with_status(content, http::StatusCode::OK);
 
             Ok(response)
         }
-        Some(exporter) => {
-            let data = exporter.registry().gather();
-            match TextEncoder::new().encode_to_string(&data) {
-                Ok(content) => {
-                    let response = warp::reply::with_status(content, http::StatusCode::OK);
+        Err(e) => {
+            error!(?e, "Failed to parse metrics");
+            let response = warp::reply::with_status(
+                "Failed to get metrics".into(),
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+            );
 
-                    Ok(response)
-                }
-                Err(e) => {
-                    error!(?e, "Failed to parse metrics");
-                    let response = warp::reply::with_status(
-                        "Failed to get metrics".into(),
-                        http::StatusCode::INTERNAL_SERVER_ERROR,
-                    );
-
-                    Ok(response)
-                }
-            }
+            Ok(response)
         }
     }
 }

--- a/src/handlers/metrics.rs
+++ b/src/handlers/metrics.rs
@@ -22,7 +22,7 @@ pub async fn handler(state: Arc<State>) -> Result<impl warp::Reply, warp::Reject
             match TextEncoder::new().encode_to_string(&data) {
                 Ok(content) => {
                     let response =
-                        warp::reply::with_status(format!("{}", content), http::StatusCode::OK);
+                        warp::reply::with_status(content, http::StatusCode::OK);
 
                     Ok(response)
                 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -2,6 +2,7 @@ use hyper::{Body, Response, StatusCode};
 use serde::Deserialize;
 
 pub mod health;
+pub mod metrics;
 pub mod proxy;
 
 #[derive(Deserialize)]

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -40,10 +40,9 @@ pub async fn handler(
     }
 
     if let Some(metrics) = &state.metrics {
-        let abc: String = query_params.chain_id.to_lowercase();
         metrics
             .rpc_call_counter
-            .add(1, &[opentelemetry::KeyValue::new("chain.id", abc)]);
+            .add(1, &[opentelemetry::KeyValue::new("chain.id", query_params.chain_id.to_lowercase())]);
     }
 
     // TODO: map the response error codes properly

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -40,9 +40,13 @@ pub async fn handler(
     }
 
     if let Some(metrics) = &state.metrics {
-        metrics
-            .rpc_call_counter
-            .add(1, &[opentelemetry::KeyValue::new("chain.id", query_params.chain_id.to_lowercase())]);
+        metrics.rpc_call_counter.add(
+            1,
+            &[opentelemetry::KeyValue::new(
+                "chain.id",
+                query_params.chain_id.to_lowercase(),
+            )],
+        );
     }
 
     // TODO: map the response error codes properly

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -39,15 +39,13 @@ pub async fn handler(
         .into_response());
     }
 
-    if let Some(metrics) = &state.metrics {
-        metrics.rpc_call_counter.add(
-            1,
-            &[opentelemetry::KeyValue::new(
-                "chain.id",
-                query_params.chain_id.to_lowercase(),
-            )],
-        );
-    }
+    state.metrics.rpc_call_counter.add(
+        1,
+        &[opentelemetry::KeyValue::new(
+            "chain.id",
+            query_params.chain_id.to_lowercase(),
+        )],
+    );
 
     // TODO: map the response error codes properly
     // e.g. HTTP401 from target should map to HTTP500

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,6 @@ use warp::Filter;
 use hyper::Client;
 use hyper_tls::HttpsConnector;
 
-// Re-export opentelemetry API.
-pub use opentelemetry::*;
-
 #[tokio::main]
 async fn main() -> error::Result<()> {
     dotenv().ok();
@@ -42,13 +39,7 @@ async fn main() -> error::Result<()> {
         .with_description("The number of rpc calls served")
         .init();
 
-    let state = state::new_state(
-        config,
-        prometheus_exporter,
-        Metrics {
-            rpc_call_counter: rpc_call_counter,
-        },
-    );
+    let state = state::new_state(config, prometheus_exporter, Metrics { rpc_call_counter });
 
     let port = state.config.port;
     let host = state.config.host.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,6 @@ async fn main() -> error::Result<()> {
     let config =
         env::get_config().expect("Failed to load config, please ensure all env vars are defined.");
 
-    let mut state = state::new_state(config);
-
     let prometheus_exporter = opentelemetry_prometheus::exporter().init();
     let meter = prometheus_exporter
         .provider()
@@ -44,7 +42,8 @@ async fn main() -> error::Result<()> {
         .with_description("The number of rpc calls served")
         .init();
 
-    state.set_metrics(
+    let state = state::new_state(
+        config,
         prometheus_exporter,
         Metrics {
             rpc_call_counter: rpc_call_counter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,10 @@ mod providers;
 mod state;
 
 use crate::env::Config;
+use crate::state::Metrics;
 use build_info::BuildInfo;
 use dotenv::dotenv;
+use opentelemetry::metrics::MeterProvider;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::info;
@@ -20,13 +22,34 @@ use warp::Filter;
 use hyper::Client;
 use hyper_tls::HttpsConnector;
 
+// Re-export opentelemetry API.
+pub use opentelemetry::*;
+
 #[tokio::main]
 async fn main() -> error::Result<()> {
     dotenv().ok();
     let config =
         env::get_config().expect("Failed to load config, please ensure all env vars are defined.");
 
-    let state = state::new_state(config);
+    let mut state = state::new_state(config);
+
+    let prometheus_exporter = opentelemetry_prometheus::exporter().init();
+    let meter = prometheus_exporter
+        .provider()
+        .unwrap()
+        .meter("rpc-proxy", None);
+
+    let rpc_call_counter = meter
+        .u64_counter("rpc_call_counter")
+        .with_description("The number of rpc calls served")
+        .init();
+
+    state.set_metrics(
+        prometheus_exporter,
+        Metrics {
+            rpc_call_counter: rpc_call_counter,
+        },
+    );
 
     let port = state.config.port;
     let host = state.config.host.clone();
@@ -42,6 +65,11 @@ async fn main() -> error::Result<()> {
         .and(state_filter.clone())
         .and_then(handlers::health::handler);
 
+    let metrics = warp::any()
+        .and(warp::path!("metrics"))
+        .and(state_filter.clone())
+        .and_then(handlers::metrics::handler);
+
     let mut providers = ProviderRepository::default();
     let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
     let infura_provider = InfuraProvider {
@@ -54,6 +82,7 @@ async fn main() -> error::Result<()> {
 
     let proxy = warp::any()
         .and(warp::path!("v1"))
+        .and(state_filter.clone())
         .and(provider_filter.clone())
         .and(warp::method())
         .and(warp::path::full())
@@ -65,6 +94,7 @@ async fn main() -> error::Result<()> {
     let routes = warp::any()
         .and(health)
         .or(proxy)
+        .or(metrics)
         .with(warp::trace::request());
 
     info!("v{}", build_version);

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,8 +4,8 @@ use opentelemetry_prometheus::PrometheusExporter;
 
 pub struct State {
     pub config: Config,
-    pub exporter: Option<PrometheusExporter>,
-    pub metrics: Option<Metrics>,
+    pub exporter: PrometheusExporter,
+    pub metrics: Metrics,
     pub build_info: BuildInfo,
 }
 
@@ -15,19 +15,13 @@ pub struct Metrics {
 
 build_info::build_info!(fn build_info);
 
-pub fn new_state(config: Config) -> State {
+pub fn new_state(config: Config, exporter: PrometheusExporter, metrics: Metrics) -> State {
     let build_info: &BuildInfo = build_info();
 
     State {
         config,
-        exporter: None,
-        metrics: None,
+        exporter,
+        metrics,
         build_info: build_info.clone(),
-    }
-}
-impl State {
-    pub fn set_metrics(&mut self, exporter: PrometheusExporter, metrics: Metrics) {
-        self.exporter = Some(exporter);
-        self.metrics = Some(metrics);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,16 @@
 use crate::{BuildInfo, Config};
+use opentelemetry::metrics::Counter;
+use opentelemetry_prometheus::PrometheusExporter;
 
 pub struct State {
     pub config: Config,
+    pub exporter: Option<PrometheusExporter>,
+    pub metrics: Option<Metrics>,
     pub build_info: BuildInfo,
+}
+
+pub struct Metrics {
+    pub rpc_call_counter: Counter<u64>,
 }
 
 build_info::build_info!(fn build_info);
@@ -12,6 +20,14 @@ pub fn new_state(config: Config) -> State {
 
     State {
         config,
+        exporter: None,
+        metrics: None,
         build_info: build_info.clone(),
+    }
+}
+impl State {
+    pub fn set_metrics(&mut self, exporter: PrometheusExporter, metrics: Metrics) {
+        self.exporter = Some(exporter);
+        self.metrics = Some(metrics);
     }
 }


### PR DESCRIPTION
Installs a call counter that let's us know how many calls we received split up by chain id.

Next step: add a prometheus instance and create a Grafana dashboard.

# Testing
Tested the `/metrics/` endpoint locally.