### PR TITLE
fix: remove wait for steady state on ecs updates

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -160,8 +160,9 @@ resource "aws_ecs_service" "app_service" {
   launch_type     = "FARGATE"
   desired_count   = 2 # Setting the number of containers we want deployed to 3
 
+  # TODO: Reactivate wait_for_steady_state when we can have custom timeouts.
   # Wait for the service deployment to succeed
-  wait_for_steady_state = true
+  #  wait_for_steady_state = true
 
   network_configuration {
     subnets          = data.aws_subnets.private_subnets.ids


### PR DESCRIPTION
# Description

Remove the `wait_for_steady_state` for ECS deployments.
It seems that the deployment takes too long, thus sending Terraform in a timeout error. This should work fine as long as we don't send updates too often and keep an eye on the cluster.
We need to update the `aws` provider so that we can provide [custom timeouts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#timeouts) (not supported in this version).

## How Has This Been Tested?

Deployed by hand to staging

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
