### PR TITLE
feat: pin rust version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Build args
 #
 ################################################################################
-ARG                 base="rust:buster"
+ARG                 base="rust:1.65-buster"
 ARG                 runtime="debian:buster-slim"
 ARG                 bin="rpc-proxy"
 ARG                 version="unknown"


### PR DESCRIPTION
# Description

We need at least Rust `1.65` to run the app. Hence, pinning the version.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
