### PR TITLE
fix(ci): application not exposed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,7 @@ LABEL               version=${version}
 LABEL               sha=${sha}
 LABEL               maintainer=${maintainer}
 
-ENV                 HOST=0.0.0.0
-ENV                 PORT=3000
+ENV                 RPC_PROXY_HOST=0.0.0.0
 
 WORKDIR             /app
 COPY --from=build   /app/target/${binpath:-debug}/rpc-proxy /usr/local/bin/rpc-proxy


### PR DESCRIPTION
# Description

We recently changed config parameters. The `Dockerfile` one wasn't updated causing the app to run on `127.0.0.1`.

## How Has This Been Tested?

Tested locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
