### PR TITLE
feat: Add docker-compose and Redis dashboards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -7,8 +7,20 @@
 ```console
 $ docker build . --tag rpc-proxy:
 $ docker run -p 3000:3000 \
+    -e RPC_PROXY_POKT_PROJECT_ID=<some_id> \
     -e RPC_PROXY_INFURA_PROJECT_ID=<some_id> \
     -e RPC_PROXY_REGISTRY_API_URL=<registry_url> \
     -e RPC_PROXY_REGISTRY_API_AUTH_TOKEN=<token> \
     --name rpc -it rpc-proxy
+```
+
+### Docker Compose
+
+If you need to test with registry caching activated, you can use `docker-compose` to spawn a redis instance for the proxy:
+
+```console
+$ RPC_PROXY_POKT_PROJECT_ID=<some_id> \
+  RPC_PROXY_INFURA_PROJECT_ID=<some_id> \
+  RPC_PROXY_REGISTRY_API_AUTH_TOKEN=<token> \
+  docker-compose up
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7.0
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis:/data
+
+  proxy:
+    platform: linux/x86_64
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - RPC_PROXY_LOG_LEVEL=DEBUG
+      - RPC_PROXY_HOST=0.0.0.0
+      - RPC_PROXY_PORT=3000
+      - RPC_PROXY_INFURA_PROJECT_ID=${RPC_PROXY_INFURA_PROJECT_ID}
+      - RPC_PROXY_POKT_PROJECT_ID=${RPC_PROXY_POKT_PROJECT_ID}
+      - RPC_PROXY_REGISTRY_API_URL=https://registry-prod-cf.walletconnect.com
+      - RPC_PROXY_REGISTRY_API_AUTH_TOKEN=${RPC_PROXY_REGISTRY_API_AUTH_TOKEN}
+      - RPC_PROXY_STORAGE_PROJECT_DATA_REDIS_ADDR_READ=redis://redis:6379
+      - RPC_PROXY_STORAGE_PROJECT_DATA_REDIS_ADDR_WRITE=redis://redis:6379
+    cap_add:
+      - SYS_PTRACE    # Enabling GDB to attach to a running process
+    depends_on:
+      - redis
+
+volumes:
+  redis:

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tap::TapFallible;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::handlers::{handshake_error, RpcQueryParams};
 use crate::providers::ProviderRepository;
@@ -25,17 +25,21 @@ pub async fn handler(
         ));
     }
 
+    debug!("querying registry for project {}", query_params.project_id);
     match state.registry.project_data(&query_params.project_id).await {
         Ok(project) => {
             if let Err(access_err) = project.validate_access(&query_params.project_id, None) {
+                debug!("project {} is invalid ({:?})", query_params.project_id, access_err);
                 state.metrics.add_rejected_project();
-                return Ok(handshake_error("projectId", format!("{access_err}")));
+                return Ok(handshake_error("projectId", format!("{:?}", access_err)));
             }
+            debug!("project {} is valid", query_params.project_id);
         }
 
         Err(err) => {
+            debug!("received error from registry: {:?}", err);
             state.metrics.add_rejected_project();
-            return Ok(handshake_error("projectId", format!("{err}")));
+            return Ok(handshake_error("projectId", format!("{:?}", err)));
         }
     }
 
@@ -46,7 +50,7 @@ pub async fn handler(
         _ => {
             return Ok(field_validation_error(
                 "chainId",
-                format!("We don't support the chainId you provided: {chain_id}"),
+                format!("We don't support the chainId you provided: {}", chain_id),
             ))
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use hyper::Client;
 use hyper_tls::HttpsConnector;
 use opentelemetry::metrics::MeterProvider;
 use std::str::FromStr;
-use tracing::{debug, info};
+use tracing::info;
 use tracing_subscriber::fmt::format::FmtSpan;
 use warp::Filter;
 
@@ -35,13 +35,10 @@ async fn main() -> error::RpcResult<()> {
 
     tracing_subscriber::fmt()
         .with_max_level(
-            tracing::Level::from_str(config.server.log_level.as_str())
-                .expect("Invalid log level"),
+            tracing::Level::from_str(config.server.log_level.as_str()).expect("Invalid log level"),
         )
         .with_span_events(FmtSpan::CLOSE)
         .init();
-
-    debug!("{:#?}", config);
 
     let prometheus_exporter = opentelemetry_prometheus::exporter().init();
     let meter = prometheus_exporter

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use hyper::Client;
 use hyper_tls::HttpsConnector;
 use opentelemetry::metrics::MeterProvider;
 use std::str::FromStr;
-use tracing::info;
+use tracing::{debug, info};
 use tracing_subscriber::fmt::format::FmtSpan;
 use warp::Filter;
 
@@ -33,6 +33,16 @@ async fn main() -> error::RpcResult<()> {
     let config =
         Config::from_env().expect("Failed to load config, please ensure all env vars are defined.");
 
+    tracing_subscriber::fmt()
+        .with_max_level(
+            tracing::Level::from_str(config.server.log_level.as_str())
+                .expect("Invalid log level"),
+        )
+        .with_span_events(FmtSpan::CLOSE)
+        .init();
+
+    debug!("{:#?}", config);
+
     let prometheus_exporter = opentelemetry_prometheus::exporter().init();
     let meter = prometheus_exporter
         .provider()
@@ -50,14 +60,6 @@ async fn main() -> error::RpcResult<()> {
     let build_version = state.build_info.crate_info.version.clone();
 
     let state_arc = Arc::new(state);
-
-    tracing_subscriber::fmt()
-        .with_max_level(
-            tracing::Level::from_str(state_arc.clone().config.server.log_level.as_str())
-                .expect("Invalid log level"),
-        )
-        .with_span_events(FmtSpan::CLOSE)
-        .init();
 
     let state_filter = warp::any().map(move || state_arc.clone());
 

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -4,8 +4,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use cerberus::registry::{RegistryClient, RegistryError, RegistryHttpClient, RegistryResult};
-use tracing::debug;
-use tracing::field::debug;
 
 pub use config::*;
 pub use error::*;
@@ -42,7 +40,6 @@ impl Registry {
         cfg_storage: &StorageConfig,
         meter: &Meter,
     ) -> RpcResult<Self> {
-        debug!("initializing registry client");
         let api_url = &cfg_registry.api_url;
         let api_auth_token = &cfg_registry.api_auth_token;
 
@@ -60,7 +57,6 @@ impl Registry {
         let cache = match cache_addr {
             None => None,
             Some(cache_addr) => {
-                debug!("found cache configuration, initializing registry cache");
                 let cache = open_redis(&cache_addr, cfg_storage.redis_max_connections)?;
 
                 Some(ProjectStorage::new(
@@ -90,19 +86,15 @@ impl Registry {
         id: &str,
     ) -> RpcResult<(ResponseSource, ProjectDataResult)> {
         if let Some(cache) = &self.cache {
-            debug!("checking cache for project {}", id);
             let time = Instant::now();
             let data = cache.fetch(id).await?;
             self.metrics.fetch_cache_time(time.elapsed());
 
             if let Some(data) = data {
-                debug!("project {} was found in cache", id);
                 return Ok((ResponseSource::Cache, data));
             }
-            debug!("project {} was not found in cache", id);
         }
 
-        debug!("fetching project {} from registry", id);
         let data = self.fetch_registry(id).await;
 
         // Cache all responses that we get, even errors.
@@ -114,10 +106,8 @@ impl Registry {
             // This is a retryable error, don't cache the result.
             Err(err) => return Err(err.into()),
         };
-        debug!("registry result: {:?}", data);
 
         if let Some(cache) = &self.cache {
-            debug!("storing project {} in cache", id);
             cache.set(id, &data).await;
         }
 

--- a/src/project/storage/mod.rs
+++ b/src/project/storage/mod.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use cerberus::project::ProjectData;
 use tap::TapFallible;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::project::error::ProjectDataError;
 use crate::project::metrics::ProjectDataMetrics;
@@ -39,6 +39,8 @@ impl ProjectStorage {
         let time = Instant::now();
 
         let cache_key = build_cache_key(id);
+        debug!("cache_key: {}", cache_key);
+
         let data = self
             .cache
             .get(&cache_key)
@@ -52,6 +54,7 @@ impl ProjectStorage {
 
     pub async fn set(&self, id: &str, data: &ProjectDataResult) {
         let cache_key = build_cache_key(id);
+        debug!("cache_key: {}", cache_key);
 
         let serialized = crate::storage::serialize(&data).unwrap(); //?;
         let cache = self.cache.clone();

--- a/src/project/storage/mod.rs
+++ b/src/project/storage/mod.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use cerberus::project::ProjectData;
 use tap::TapFallible;
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::project::error::ProjectDataError;
 use crate::project::metrics::ProjectDataMetrics;
@@ -39,7 +39,6 @@ impl ProjectStorage {
         let time = Instant::now();
 
         let cache_key = build_cache_key(id);
-        debug!("cache_key: {}", cache_key);
 
         let data = self
             .cache
@@ -54,7 +53,6 @@ impl ProjectStorage {
 
     pub async fn set(&self, id: &str, data: &ProjectDataResult) {
         let cache_key = build_cache_key(id);
-        debug!("cache_key: {}", cache_key);
 
         let serialized = crate::storage::serialize(&data).unwrap(); //?;
         let cache = self.cache.clone();
@@ -65,7 +63,7 @@ impl ProjectStorage {
             cache
                 .set_serialized(&cache_key, &serialized, Some(cache_ttl))
                 .await
-                .tap_err(|err| warn!("failed to cache project data: {err:?}"))
+                .tap_err(|err| warn!("failed to cache project data: {:?}", err))
                 .ok();
         });
     }
@@ -73,5 +71,5 @@ impl ProjectStorage {
 
 #[inline]
 fn build_cache_key(id: &str) -> String {
-    format!("project-data/{id}")
+    format!("project-data/{}", id)
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,6 +84,7 @@ module "o11y" {
 
   prometheus_workspace_id = aws_prometheus_workspace.prometheus.id
   environment             = terraform.workspace
+  redis_cluster_id        = module.redis.cluster_id
 }
 
 resource "aws_prometheus_workspace" "prometheus" {

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -9,6 +9,15 @@ terraform {
   }
 }
 
+locals {
+  opsgenie_notification_channel = "l_iaPw6nk"
+  notifications = (
+    var.environment == "prod" ?
+    "[{\"uid\": \"${local.opsgenie_notification_channel}\"}]" :
+    "[]"
+  )
+}
+
 resource "grafana_data_source" "prometheus" {
   type = "prometheus"
   name = "${var.environment}-rpc-proxy-amp"
@@ -64,6 +73,9 @@ resource "grafana_dashboard" "at_a_glance" {
     liveNow : false,
     panels : [
       {
+        title : "Calls by Chain ID",
+        type : "timeseries"
+        id : 2,
         datasource : {
           type : "prometheus",
           uid : grafana_data_source.prometheus.uid
@@ -119,12 +131,9 @@ resource "grafana_dashboard" "at_a_glance" {
           overrides : []
         },
         gridPos : {
-          h : 9,
-          w : 12,
-          x : 0,
-          y : 0
+          x : 0, y : 0,
+          h : 9, w : 12,
         },
-        id : 2,
         options : {
           legend : {
             calcs : [],
@@ -149,10 +158,11 @@ resource "grafana_dashboard" "at_a_glance" {
             refId : "A"
           }
         ],
-        title : "Calls by Chain ID",
-        type : "timeseries"
       },
       {
+        title : "Calls by Chain ID",
+        type : "timeseries"
+        id : 3,
         datasource : {
           type : "prometheus",
           uid : grafana_data_source.prometheus.uid
@@ -208,12 +218,9 @@ resource "grafana_dashboard" "at_a_glance" {
           overrides : []
         },
         gridPos : {
-          h : 9,
-          w : 12,
-          x : 12,
-          y : 0
+          x : 12, y : 0,
+          h : 9, w : 12,
         },
-        id : 4,
         options : {
           legend : {
             calcs : [],
@@ -238,10 +245,11 @@ resource "grafana_dashboard" "at_a_glance" {
             refId : "A"
           }
         ],
-        title : "Calls by Chain ID",
-        type : "timeseries"
       },
       {
+        title : "Calls by Chain ID",
+        type : "timeseries"
+        id : 4,
         datasource : {
           type : "prometheus",
           uid : grafana_data_source.prometheus.uid
@@ -297,12 +305,9 @@ resource "grafana_dashboard" "at_a_glance" {
           overrides : []
         },
         gridPos : {
-          h : 9,
-          w : 12,
-          x : 0,
-          y : 9
+          x : 0, y : 9,
+          h : 9, w : 12,
         },
-        id : 5,
         options : {
           legend : {
             calcs : [],
@@ -327,10 +332,11 @@ resource "grafana_dashboard" "at_a_glance" {
             refId : "A"
           }
         ],
-        title : "Calls by Chain ID",
-        type : "timeseries"
       },
       {
+        title : "Latency",
+        type : "timeseries"
+        id : 5,
         datasource : {
           type : "prometheus",
           uid : grafana_data_source.prometheus.uid
@@ -387,12 +393,9 @@ resource "grafana_dashboard" "at_a_glance" {
           overrides : []
         },
         gridPos : {
-          h : 9,
-          w : 12,
-          x : 12,
-          y : 9
+          x : 12, y : 9,
+          h : 9, w : 12,
         },
-        id : 6,
         options : {
           legend : {
             calcs : [],
@@ -417,10 +420,11 @@ resource "grafana_dashboard" "at_a_glance" {
             refId : "A"
           }
         ],
-        title : "Latency",
-        type : "timeseries"
       },
       {
+        title : "Availability",
+        type : "timeseries"
+        id : 6,
         datasource : {
           type : "prometheus",
           uid : grafana_data_source.prometheus.uid
@@ -479,12 +483,9 @@ resource "grafana_dashboard" "at_a_glance" {
           overrides : []
         },
         gridPos : {
-          h : 9,
-          w : 12,
-          x : 12,
-          y : 9
+          x : 12, y : 9,
+          h : 9, w : 12,
         },
-        id : 6,
         options : {
           legend : {
             calcs : [],
@@ -545,11 +546,12 @@ resource "grafana_dashboard" "at_a_glance" {
           }
         ],
         thresholds : [],
-        title : "Availability",
-        type : "timeseries"
       },
 
       {
+        title : "Registry Requests by Status Code",
+        type : "timeseries"
+        id : 7,
         datasource : {
           type : "prometheus",
           uid : grafana_data_source.prometheus.uid
@@ -605,12 +607,9 @@ resource "grafana_dashboard" "at_a_glance" {
           overrides : []
         },
         gridPos : {
-          h : 8,
-          w : 9,
-          x : 0,
-          y : 0
+          x : 0, y : 0,
+          h : 9, w : 12,
         },
-        id : 50,
         options : {
           legend : {
             calcs : [],
@@ -636,10 +635,196 @@ resource "grafana_dashboard" "at_a_glance" {
             refId : "A"
           }
         ],
-        title : "Registry Requests by Status Code",
+      },
+
+      {
+        title : "Redis CPU/Memory",
         type : "timeseries"
+        id : 8,
+        alert : {
+          alertRuleTags : {
+            priority : "P2"
+          },
+          conditions : [
+            {
+              evaluator : {
+                params : [
+                  50
+                ],
+                type : "gt"
+              },
+              operator : {
+                type : "or"
+              },
+              query : {
+                params : [
+                  "B",
+                  "5m",
+                  "now"
+                ]
+              },
+              reducer : {
+                params : [],
+                type : "max"
+              },
+              type : "query"
+            },
+            {
+              evaluator : {
+                params : [
+                  50
+                ],
+                type : "gt"
+              },
+              operator : {
+                type : "or"
+              },
+              query : {
+                params : [
+                  "A",
+                  "5m",
+                  "now"
+                ]
+              },
+              reducer : {
+                params : [],
+                type : "max"
+              },
+              type : "query"
+            }
+          ],
+          executionErrorState : "alerting",
+          for : "5m",
+          frequency : "1m",
+          handler : 1,
+          message : "${var.environment} CPU/Memory alert",
+          name : "${var.environment} CPU/Memory alert",
+          noDataState : "alerting",
+          notifications : local.notifications
+        },
+        datasource : {
+          type : "cloudwatch",
+          uid : grafana_data_source.cloudwatch.uid
+        },
+        fieldConfig : {
+          defaults : {
+            color : {
+              mode : "palette-classic"
+            },
+            custom : {
+              axisLabel : "",
+              axisPlacement : "auto",
+              axisSoftMax : 100,
+              axisSoftMin : 0,
+              barAlignment : 0,
+              drawStyle : "line",
+              fillOpacity : 0,
+              gradientMode : "none",
+              hideFrom : {
+                legend : false,
+                tooltip : false,
+                viz : false
+              },
+              lineInterpolation : "linear",
+              lineWidth : 1,
+              pointSize : 5,
+              scaleDistribution : {
+                type : "linear"
+              },
+              showPoints : "auto",
+              spanNulls : false,
+              stacking : {
+                group : "A",
+                mode : "none"
+              },
+              thresholdsStyle : {
+                mode : "area"
+              }
+            },
+            mappings : [],
+            thresholds : {
+              mode : "absolute",
+              steps : [
+                {
+                  color : "green",
+                  value : null
+                },
+                {
+                  color : "red",
+                  value : 50
+                }
+              ]
+            }
+          },
+          overrides : []
+        },
+        gridPos : {
+          x : 12, y : 0,
+          h : 9, w : 12,
+        },
+        options : {
+          legend : {
+            calcs : [],
+            displayMode : "list",
+            placement : "bottom"
+          },
+          tooltip : {
+            mode : "single",
+            sort : "none"
+          }
+        },
+        targets : [
+          {
+            alias : "",
+            datasource : {
+              type : "cloudwatch",
+              uid : grafana_data_source.cloudwatch.uid
+            },
+            dimensions : {
+              CacheClusterId : var.redis_cluster_id
+            },
+            expression : "",
+            id : "",
+            matchExact : true,
+            metricEditorMode : 0,
+            metricName : "CPUUtilization",
+            metricQueryType : 0,
+            namespace : "AWS/ElastiCache",
+            period : "",
+            queryMode : "Metrics",
+            refId : "A",
+            region : "default",
+            sqlExpression : "",
+            statistic : "Maximum"
+          },
+          {
+            alias : "",
+            datasource : {
+              type : "cloudwatch",
+              uid : grafana_data_source.cloudwatch.uid
+            },
+            dimensions : {
+              CacheClusterId : var.redis_cluster_id
+            },
+            expression : "",
+            hide : false,
+            id : "",
+            matchExact : true,
+            metricEditorMode : 0,
+            metricName : "DatabaseMemoryUsagePercentage",
+            metricQueryType : 0,
+            namespace : "AWS/ElastiCache",
+            period : "",
+            queryMode : "Metrics",
+            refId : "B",
+            region : "default",
+            sqlExpression : "",
+            statistic : "Maximum"
+          }
+        ],
       }
     ],
+
     schemaVersion : 36,
     style : "dark",
     tags : [],

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -5,3 +5,7 @@ variable "environment" {
 variable "prometheus_workspace_id" {
   type = string
 }
+
+variable "redis_cluster_id" {
+  type = string
+}


### PR DESCRIPTION
# Description

- Add a `docker-compose` definition to run locally with a Redis instance
- Add a dashboard panel and alert in Grafana for the Redis instance.

Resolves #40 

## How Has This Been Tested?

Deployed manually to `staging`.

![image](https://user-images.githubusercontent.com/160293/202666262-5bd01c77-df22-4243-8e57-a16ff4a5268d.png)

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
