### PR TITLE
Chore/monitor rate limits

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -30,6 +30,11 @@ impl Metrics {
             .with_description("The number of calls for invalid project ids")
             .init();
 
+        let rate_limited_counter = meter
+            .u64_counter("rate_limited_counter")
+            .with_description("The number of calls that got rate limited")
+            .init();
+
         Metrics {
             rpc_call_counter,
             http_call_counter,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,6 +6,7 @@ pub struct Metrics {
     pub http_call_counter: Counter<u64>,
     pub http_latency_tracker: Counter<f64>,
     pub rejected_project_counter: Counter<u64>,
+    pub rate_limited_call_counter: Counter<u64>,
 }
 
 impl Metrics {
@@ -30,7 +31,7 @@ impl Metrics {
             .with_description("The number of calls for invalid project ids")
             .init();
 
-        let rate_limited_counter = meter
+        let rate_limited_call_counter = meter
             .u64_counter("rate_limited_counter")
             .with_description("The number of calls that got rate limited")
             .init();
@@ -40,6 +41,7 @@ impl Metrics {
             http_call_counter,
             http_latency_tracker,
             rejected_project_counter,
+            rate_limited_call_counter,
         }
     }
 }
@@ -77,5 +79,15 @@ impl Metrics {
 
     pub fn add_rejected_project(&self) {
         self.rejected_project_counter.add(1, &[])
+    }
+
+    pub fn add_rate_limited_call(&self, provider: &str) {
+        self.rate_limited_call_counter.add(
+            1,
+            &[opentelemetry::KeyValue::new(
+                "provider",
+                provider.to_owned(),
+            )],
+        )
     }
 }

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -3,7 +3,7 @@ use crate::error::{RpcError, RpcResult};
 use async_trait::async_trait;
 use hyper::{client::HttpConnector, Body, Client, Response};
 use hyper_tls::HttpsConnector;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 #[derive(Clone)]
 pub struct InfuraProvider {
@@ -46,5 +46,11 @@ impl RpcProvider for InfuraProvider {
 
     fn supported_caip_chainids(&self) -> Vec<String> {
         self.supported_chains.keys().cloned().collect()
+    }
+}
+
+impl Display for InfuraProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "InfuraProvider: {}", self.project_id)
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -8,6 +8,7 @@ use hyper::Response;
 pub use infura::InfuraProvider;
 pub use pokt::PoktProvider;
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::sync::Arc;
 
 #[derive(Default, Clone)]
@@ -30,7 +31,7 @@ impl ProviderRepository {
 }
 
 #[async_trait]
-pub trait RpcProvider: Send + Sync {
+pub trait RpcProvider: Send + Sync + Display {
     async fn proxy(
         &self,
         method: hyper::http::Method,

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -3,7 +3,7 @@ use crate::error::{RpcError, RpcResult};
 use async_trait::async_trait;
 use hyper::{client::HttpConnector, Body, Client, Response};
 use hyper_tls::HttpsConnector;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 #[derive(Clone)]
 pub struct PoktProvider {
@@ -49,5 +49,11 @@ impl RpcProvider for PoktProvider {
 
     fn supported_caip_chainids(&self) -> Vec<String> {
         self.supported_chains.keys().cloned().collect()
+    }
+}
+
+impl Display for PoktProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Pokt Provider: {}", self.project_id)
     }
 }


### PR DESCRIPTION
# Description

Implemented Display for Providers, made it a required trait for Provider.
On each proxied request to provider, on successful response, check for HTTP 429 and store such occurences in metrics with provider info (provider and project id).
Implements functionality requested in issue #32  

Resolves #32 

## How Has This Been Tested?

Untested for now. As I don't want to force rate limit for either infura or pokt, I'll try to intercept the traffic and force-feed the proxy with HTTP 429 to test it.


## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
