### PR TITLE
fix: don't use ansi in logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ opentelemetry = { version = "0.17.0", features = ["trace", "metrics", "rt-tokio"
 opentelemetry-prometheus = "0.10.0"
 prometheus-core = { package = "prometheus", version = "0.13" }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json"] }
+tracing-subscriber = { version = "0.3", features = ["json", "ansi"] }
 
 cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.1.2" }
 gorgon = { git = "https://github.com/WalletConnect/gorgon.git", tag = "v0.1.1" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> error::RpcResult<()> {
             tracing::Level::from_str(config.server.log_level.as_str()).expect("Invalid log level"),
         )
         .with_span_events(FmtSpan::CLOSE)
-        .json()
+        .with_ansi(false)
         .init();
 
     let prometheus_exporter = opentelemetry_prometheus::exporter().init();


### PR DESCRIPTION
# Description

Don't use ANSI in logs

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
