### PR TITLE
fix: Add access to analytics KMS key to ECS role policy

### DIFF
--- a/terraform/analytics.tf
+++ b/terraform/analytics.tf
@@ -19,7 +19,7 @@ resource "aws_s3_bucket_public_access_block" "analytics_bucket" {
 }
 
 resource "aws_kms_key" "analytics_bucket" {
-  description             = "key to encrypt analytics bucket objects"
+  description             = "${terraform.workspace} - analytics bucket encryption"
   enable_key_rotation     = true
   deletion_window_in_days = 10
 }

--- a/terraform/ecs/iam.tf
+++ b/terraform/ecs/iam.tf
@@ -65,6 +65,12 @@ resource "aws_iam_policy" "analytics_bucket_access" {
         "Effect" : "Allow",
         "Action" : ["s3:CopyObject", "s3:GetObject", "s3:HeadObject"],
         "Resource" : ["arn:aws:s3:::${var.analytics_geoip_db_bucket_name}/*"]
+      },
+      {
+        "Sid" : "AllObjectActionsInGeoipBucket",
+        "Effect" : "Allow",
+        "Action" : ["kms:GenerateDataKey"],
+        "Resource" : [var.analytics_key_arn]
       }
     ]
   })

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -74,3 +74,7 @@ variable "analytics_geoip_db_key" {
 variable "analytics_geoip_db_bucket_name" {
   type = string
 }
+
+variable "analytics_key_arn" {
+  type = string
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -56,6 +56,7 @@ module "ecs" {
   project_data_redis_endpoint_write = module.redis.endpoint
 
   analytics_bucket_name          = aws_s3_bucket.analytics_bucket.bucket
+  analytics_key_arn              = aws_kms_key.analytics_bucket.arn
   analytics_geoip_db_bucket_name = local.analytics_geoip_db_bucket_name
   analytics_geoip_db_key         = var.analytics_geoip_db_key
 }


### PR DESCRIPTION
# Description

Add the `kms:GenerateDataKey` permission to the ECS role bucket policy


## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
