### PR TITLE
fix: remove legacy analytics exports

### DIFF
--- a/src/analytics/config.rs
+++ b/src/analytics/config.rs
@@ -4,7 +4,6 @@ use serde_piecewise_default::DeserializePiecewiseDefault;
 #[derive(DeserializePiecewiseDefault, Debug, Clone, Default, PartialEq, Eq)]
 pub struct Config {
     pub export_bucket: Option<String>,
-    pub legacy_export_bucket: Option<String>,
     pub geoip_db_bucket: Option<String>,
     pub geoip_db_key: Option<String>,
 }

--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -7,35 +7,6 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
 #[serde(rename_all = "camelCase")]
-pub struct LegacyMessageInfo {
-    pub timestamp: String,
-
-    pub project_id: String,
-    pub chain_id: String,
-    pub method: Arc<str>,
-
-    pub sender: Option<String>,
-
-    pub country: Option<Arc<str>>,
-    pub continent: Option<Arc<str>>,
-}
-
-impl From<MessageInfo> for LegacyMessageInfo {
-    fn from(value: MessageInfo) -> Self {
-        Self {
-            timestamp: gorgon::time::format(&value.timestamp),
-            project_id: value.project_id,
-            chain_id: value.chain_id,
-            method: value.method,
-            sender: value.sender.clone(),
-            country: value.country.clone(),
-            continent: value.continent.clone(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
-#[serde(rename_all = "camelCase")]
 pub struct MessageInfo {
     pub timestamp: chrono::NaiveDateTime,
 

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -4,7 +4,7 @@ pub use config::Config;
 use gorgon::batcher::{AwsExporter, AwsExporterOpts, BatchCollectorOpts};
 use gorgon::geoip::{AnalyticsGeoData, GeoIpReader};
 use gorgon::{Analytics, NoopCollector};
-pub use message_info::{LegacyMessageInfo, MessageInfo};
+pub use message_info::MessageInfo;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::info;
@@ -15,7 +15,6 @@ mod message_info;
 #[derive(Clone)]
 pub struct RPCAnalytics {
     messages: Analytics<MessageInfo>,
-    legacy_messages: Analytics<LegacyMessageInfo>,
     geoip: GeoIpReader,
 }
 
@@ -24,7 +23,6 @@ const AWS_REGION: &str = "eu-central-1";
 impl RPCAnalytics {
     pub async fn new(config: &Config, proxy_ip: IpAddr) -> anyhow::Result<Self> {
         if let Some(export_bucket) = config.export_bucket.as_deref() {
-            let legacy_export_bucket = config.legacy_export_bucket.as_deref().unwrap();
             let aws_config = aws_config::from_env().region(AWS_REGION).load().await;
             let s3_client = S3Client::new(&aws_config);
             let geoip_params = (&config.geoip_db_bucket, &config.geoip_db_key);
@@ -41,13 +39,7 @@ impl RPCAnalytics {
                 GeoIpReader::empty()
             };
 
-            Self::with_aws_export(
-                s3_client,
-                legacy_export_bucket,
-                export_bucket,
-                proxy_ip,
-                geoip,
-            )
+            Self::with_aws_export(s3_client, export_bucket, proxy_ip, geoip)
         } else {
             Ok(Self::with_noop_export())
         }
@@ -58,14 +50,12 @@ impl RPCAnalytics {
 
         Self {
             messages: Analytics::new(NoopCollector),
-            legacy_messages: Analytics::new(NoopCollector),
             geoip: GeoIpReader::empty(),
         }
     }
 
     pub fn with_aws_export(
         s3_client: S3Client,
-        legacy_bucket_name: &str,
         bucket_name: &str,
         node_ip: IpAddr,
         geoip: GeoIpReader,
@@ -74,26 +64,10 @@ impl RPCAnalytics {
 
         let node_ip: Arc<str> = node_ip.to_string().into();
 
-        let legacy_messages = {
-            let legacy_opts = BatchCollectorOpts::default();
-            let exporter = AwsExporter::new(AwsExporterOpts {
-                export_name: "message_parquet",
-                file_extension: "parquet",
-                bucket_name: legacy_bucket_name.into(),
-                s3_client: s3_client.clone(),
-                node_ip: node_ip.clone(),
-            });
-
-            Analytics::new(gorgon::batcher::create_parquet_collector::<
-                LegacyMessageInfo,
-                _,
-            >(legacy_opts, exporter)?)
-        };
-
         let messages = {
             let opts = BatchCollectorOpts::default();
             let exporter = AwsExporter::new(AwsExporterOpts {
-                export_name: "message_parquet",
+                export_name: "rpc_requests",
                 file_extension: "parquet",
                 bucket_name: bucket_name.into(),
                 s3_client,
@@ -105,15 +79,10 @@ impl RPCAnalytics {
             )?)
         };
 
-        Ok(Self {
-            messages,
-            legacy_messages,
-            geoip,
-        })
+        Ok(Self { messages, geoip })
     }
 
     pub fn message(&self, data: MessageInfo) {
-        self.legacy_messages.collect(data.clone().into());
         self.messages.collect(data);
     }
 

--- a/terraform/analytics.tf
+++ b/terraform/analytics.tf
@@ -11,48 +11,6 @@ resource "aws_kms_alias" "analytics_bucket" {
 
 ################################################################################
 
-# Analytics S3 Bucket
-#tfsec:ignore:aws-s3-enable-bucket-logging
-resource "aws_s3_bucket" "analytics_bucket" {
-  bucket = "walletconnect.${local.app_name}.${terraform.workspace}.analytics"
-}
-
-resource "aws_s3_bucket_acl" "analytics_acl" {
-  bucket = aws_s3_bucket.analytics_bucket.id
-  acl    = "private"
-}
-
-resource "aws_s3_bucket_public_access_block" "analytics_bucket" {
-  bucket = aws_s3_bucket.analytics_bucket.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "analytics_bucket" {
-  bucket = aws_s3_bucket.analytics_bucket.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.analytics_bucket.arn
-      sse_algorithm     = "aws:kms"
-    }
-    bucket_key_enabled = true
-  }
-}
-
-resource "aws_s3_bucket_versioning" "analytics_bucket" {
-  bucket = aws_s3_bucket.analytics_bucket.id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-################################################################################
-
 #tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "analytics-data-lake_bucket" {
   bucket = "walletconnect.${local.app_name}.${terraform.workspace}.analytics.data-lake"

--- a/terraform/ecs/iam.tf
+++ b/terraform/ecs/iam.tf
@@ -31,56 +31,6 @@ resource "aws_iam_role_policy_attachment" "prometheus_write_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"
 }
 
-# Analytics Legacy Bucket Access
-resource "aws_iam_policy" "analytics_bucket_access" {
-  name        = "${var.app_name}_analytics_bucket_access"
-  path        = "/"
-  description = "Allows ${var.app_name} to read/write from ${var.analytics_bucket_name}"
-
-  # Terraform's "jsonencode" function converts a
-  # Terraform expression result to valid JSON syntax.
-  policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Sid" : "ListObjectsInAnalyticsBucket",
-        "Effect" : "Allow",
-        "Action" : ["s3:ListBucket"],
-        "Resource" : ["arn:aws:s3:::${var.analytics_bucket_name}"]
-      },
-      {
-        "Sid" : "AllObjectActionsInAnalyticsBucket",
-        "Effect" : "Allow",
-        "Action" : ["s3:CopyObject", "s3:DeleteObject", "s3:GetObject", "s3:HeadObject", "s3:PutObject", "s3:RestoreObject"],
-        "Resource" : ["arn:aws:s3:::${var.analytics_bucket_name}/*"]
-      },
-      {
-        "Sid" : "ListObjectsInGeoipBucket",
-        "Effect" : "Allow",
-        "Action" : ["s3:ListBucket"],
-        "Resource" : ["arn:aws:s3:::${var.analytics_geoip_db_bucket_name}"]
-      },
-      {
-        "Sid" : "AllObjectActionsInGeoipBucket",
-        "Effect" : "Allow",
-        "Action" : ["s3:CopyObject", "s3:GetObject", "s3:HeadObject"],
-        "Resource" : ["arn:aws:s3:::${var.analytics_geoip_db_bucket_name}/*"]
-      },
-      {
-        "Sid" : "AllGenerateDataKeyForAnalyticsBucket",
-        "Effect" : "Allow",
-        "Action" : ["kms:GenerateDataKey"],
-        "Resource" : [var.analytics_key_arn]
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "analytics-bucket-policy-attach" {
-  role       = aws_iam_role.ecs_task_execution_role.name
-  policy_arn = aws_iam_policy.analytics-data-lake_bucket_access.arn
-}
-
 # Analytics Bucket Access
 resource "aws_iam_policy" "analytics-data-lake_bucket_access" {
   name        = "${var.app_name}_analytics-data-lake_bucket_access"

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -74,7 +74,6 @@ resource "aws_ecs_task_definition" "app_task" {
         { name : "RPC_PROXY_STORAGE_PROJECT_DATA_REDIS_ADDR_READ", value : "redis://${var.project_data_redis_endpoint_read}/0" },
         { name : "RPC_PROXY_STORAGE_PROJECT_DATA_REDIS_ADDR_WRITE", value : "redis://${var.project_data_redis_endpoint_write}/0" },
 
-        { "name" : "RPC_PROXY_ANALYTICS_LEGACY_EXPORT_BUCKET", "value" : var.analytics_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_EXPORT_BUCKET", "value" : var.analytics-data-lake_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_BUCKET", "value" : var.analytics_geoip_db_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_KEY", "value" : var.analytics_geoip_db_key },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -63,10 +63,6 @@ variable "project_data_redis_endpoint_write" {
   type = string
 }
 
-variable "analytics_bucket_name" {
-  type = string
-}
-
 variable "analytics-data-lake_bucket_name" {
   type = string
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,7 +55,6 @@ module "ecs" {
   project_data_redis_endpoint_read  = module.redis.endpoint
   project_data_redis_endpoint_write = module.redis.endpoint
 
-  analytics_bucket_name           = aws_s3_bucket.analytics_bucket.bucket
   analytics-data-lake_bucket_name = aws_s3_bucket.analytics-data-lake_bucket.bucket
   analytics_key_arn               = aws_kms_key.analytics_bucket.arn
   analytics_geoip_db_bucket_name  = local.analytics_geoip_db_bucket_name


### PR DESCRIPTION
# Description

- Remove legacy analytics export
- Rename analytics to `rpc_requests`

## How Has This Been Tested?

`terraform plan` on staging

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
