### PR TITLE
fix: add `force_delete` flag to legacy bucket

### DIFF
--- a/terraform/analytics.tf
+++ b/terraform/analytics.tf
@@ -11,6 +11,49 @@ resource "aws_kms_alias" "analytics_bucket" {
 
 ################################################################################
 
+# Analytics S3 Bucket
+#tfsec:ignore:aws-s3-enable-bucket-logging
+resource "aws_s3_bucket" "analytics_bucket" {
+  bucket        = "walletconnect.${local.app_name}.${terraform.workspace}.analytics"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "analytics_acl" {
+  bucket = aws_s3_bucket.analytics_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "analytics_bucket" {
+  bucket = aws_s3_bucket.analytics_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "analytics_bucket" {
+  bucket = aws_s3_bucket.analytics_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.analytics_bucket.arn
+      sse_algorithm     = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "analytics_bucket" {
+  bucket = aws_s3_bucket.analytics_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+################################################################################
+
 #tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "analytics-data-lake_bucket" {
   bucket = "walletconnect.${local.app_name}.${terraform.workspace}.analytics.data-lake"

--- a/terraform/ecs/iam.tf
+++ b/terraform/ecs/iam.tf
@@ -31,6 +31,56 @@ resource "aws_iam_role_policy_attachment" "prometheus_write_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"
 }
 
+# Analytics Legacy Bucket Access
+resource "aws_iam_policy" "analytics_bucket_access" {
+  name        = "${var.app_name}_analytics_bucket_access"
+  path        = "/"
+  description = "Allows ${var.app_name} to read/write from ${var.analytics_bucket_name}"
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "ListObjectsInAnalyticsBucket",
+        "Effect" : "Allow",
+        "Action" : ["s3:ListBucket"],
+        "Resource" : ["arn:aws:s3:::${var.analytics_bucket_name}"]
+      },
+      {
+        "Sid" : "AllObjectActionsInAnalyticsBucket",
+        "Effect" : "Allow",
+        "Action" : ["s3:CopyObject", "s3:DeleteObject", "s3:GetObject", "s3:HeadObject", "s3:PutObject", "s3:RestoreObject"],
+        "Resource" : ["arn:aws:s3:::${var.analytics_bucket_name}/*"]
+      },
+      {
+        "Sid" : "ListObjectsInGeoipBucket",
+        "Effect" : "Allow",
+        "Action" : ["s3:ListBucket"],
+        "Resource" : ["arn:aws:s3:::${var.analytics_geoip_db_bucket_name}"]
+      },
+      {
+        "Sid" : "AllObjectActionsInGeoipBucket",
+        "Effect" : "Allow",
+        "Action" : ["s3:CopyObject", "s3:GetObject", "s3:HeadObject"],
+        "Resource" : ["arn:aws:s3:::${var.analytics_geoip_db_bucket_name}/*"]
+      },
+      {
+        "Sid" : "AllGenerateDataKeyForAnalyticsBucket",
+        "Effect" : "Allow",
+        "Action" : ["kms:GenerateDataKey"],
+        "Resource" : [var.analytics_key_arn]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "analytics-bucket-policy-attach" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.analytics-data-lake_bucket_access.arn
+}
+
 # Analytics Bucket Access
 resource "aws_iam_policy" "analytics-data-lake_bucket_access" {
   name        = "${var.app_name}_analytics-data-lake_bucket_access"

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -74,6 +74,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { name : "RPC_PROXY_STORAGE_PROJECT_DATA_REDIS_ADDR_READ", value : "redis://${var.project_data_redis_endpoint_read}/0" },
         { name : "RPC_PROXY_STORAGE_PROJECT_DATA_REDIS_ADDR_WRITE", value : "redis://${var.project_data_redis_endpoint_write}/0" },
 
+        { "name" : "RPC_PROXY_ANALYTICS_LEGACY_EXPORT_BUCKET", "value" : var.analytics_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_EXPORT_BUCKET", "value" : var.analytics-data-lake_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_BUCKET", "value" : var.analytics_geoip_db_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_KEY", "value" : var.analytics_geoip_db_key },

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -63,6 +63,10 @@ variable "project_data_redis_endpoint_write" {
   type = string
 }
 
+variable "analytics_bucket_name" {
+  type = string
+}
+
 variable "analytics-data-lake_bucket_name" {
   type = string
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -55,6 +55,7 @@ module "ecs" {
   project_data_redis_endpoint_read  = module.redis.endpoint
   project_data_redis_endpoint_write = module.redis.endpoint
 
+  analytics_bucket_name           = aws_s3_bucket.analytics_bucket.bucket
   analytics-data-lake_bucket_name = aws_s3_bucket.analytics-data-lake_bucket.bucket
   analytics_key_arn               = aws_kms_key.analytics_bucket.arn
   analytics_geoip_db_bucket_name  = local.analytics_geoip_db_bucket_name


### PR DESCRIPTION
# Description

Add the `force_delete` flag to the legacy analytics bucket to enable deletion.

## How Has This Been Tested?

Manual deployment on staging.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
