### PR TITLE
fix: open sg for ecs to internet

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -149,8 +149,8 @@ resource "aws_ecs_service" "app_service" {
 
   network_configuration {
     subnets          = data.aws_subnets.private_subnets.ids
-    assign_public_ip = false                                                                     # We do public ingress through the LB
-    security_groups  = [aws_security_group.tls_ingess.id, aws_security_group.vpc_app_ingress.id] # Setting the security group
+    assign_public_ip = false                                                                      # We do public ingress through the LB
+    security_groups  = [aws_security_group.tls_ingress.id, aws_security_group.vpc_app_ingress.id] # Setting the security group
   }
 
   load_balancer {


### PR DESCRIPTION
# Description

Open up the security group for the ECS task to internet since the load balancer forwards the client IP.

## How Has This Been Tested?

Deployed and tested on staging

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
