### PR TITLE
fix: set Prometheus auth method to correct value

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -27,7 +27,7 @@ resource "grafana_data_source" "prometheus" {
     httpMethod    = "GET"
     manageAlerts  = false
     sigV4Auth     = true
-    sigV4AuthType = "workspace-iam-role"
+    sigV4AuthType = "ec2_iam_role"
     sigV4Region   = "eu-central-1"
   })
 }


### PR DESCRIPTION
# Description

Set the auth method to the correct value (`ec2_iam_role`) for Grafana authentication to Prometheus.
The manual "Save & Test" that used to be required before should not be necessary anymore.

## How Has This Been Tested?

Deployed on `staging`.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
