### PR TITLE
feat: added tracking of external latency

### DIFF
--- a/src/project/metrics/mod.rs
+++ b/src/project/metrics/mod.rs
@@ -16,6 +16,7 @@ pub struct ProjectDataMetrics {
     registry_api_time: ValueRecorder<f64>,
     local_cache_time: ValueRecorder<f64>,
     total_time: ValueRecorder<f64>,
+    provider_time: ValueRecorder<f64>,
 }
 
 impl ProjectDataMetrics {
@@ -40,10 +41,16 @@ impl ProjectDataMetrics {
             .with_description("Average total latency for project data fetching")
             .init();
 
+        let provider_time = meter
+            .f64_value_recorder(create_counter_name("provider_time"))
+            .with_description("Average latency added by external provider")
+            .init();
+
         Self {
             requests_total,
             registry_api_time,
             local_cache_time,
+            provider_time,
             total_time,
         }
     }


### PR DESCRIPTION
# Description

Measures time spent on communication with external proxy. 
This with total latency will allow gathering information on both overall latency performance and the both our proxy and external providers performance, allowing insight into source of eventual latency. 

Resolves #52

## How Has This Been Tested?

The graph will be added to graphana dashboard and latency will be tracked


## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
