### PR TITLE
fix: project id env variable not set

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: 1G
       SCCACHE_DIR: ${{ matrix.sccache-path }}
+      PROJECT_ID: ${{ secrets.PROJECT_ID }}
       
     steps:
       # Checkout code


### PR DESCRIPTION
Project id not modeled. Not sure this worked before.

## How Has This Been Tested?



## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
