### PR TITLE
fix: removed unnecesary requirement for zksync project_id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ export RPC_PROXY_REGISTRY_API_AUTH_TOKEN="See 1Password: cloudflare-workers/prod
 export RPC_PROXY_STORAGE_PROJECT_DATA_REDIS_ADDR_READ="redis://localhost:6379/0"
 export RPC_PROXY_STORAGE_PROJECT_DATA_REDIS_ADDR_WRITE="redis://localhost:6379/0"
 
+
+export TEST_RPC_PROXY_PROJECT_ID=""
+
 export RPC_PROXY_INFURA_PROJECT_ID=""
 export RPC_PROXY_POKT_PROJECT_ID=""
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
 
       - name: "Task ${{ matrix.cargo.name }}"
         env:
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          TEST_RPC_PROXY_PROJECT_ID: ${{ secrets.PROJECT_ID }}
           RPC_PROXY_INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }} 
           RPC_PROXY_REGISTRY_API_URL: ${{ secrets.REGISTRY_URL }}
           RPC_PROXY_REGISTRY_API_AUTH_TOKEN: ${{ secrets.RPC_PROXY_REGISTRY_API_AUTH_TOKEN }}

--- a/src/env/zksync.rs
+++ b/src/env/zksync.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ZKSyncConfig {
+    #[serde(default)]
     pub project_id: String,
 
     #[serde(default = "default_zksync_supported_chains")]

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -32,7 +32,8 @@ impl RpcProxy {
 
         let (signal, shutdown) = broadcast::channel(1);
 
-        let project_id = env::var("PROJECT_ID").expect("PROJECT_ID must be set");
+        let project_id =
+            env::var("TEST_RPC_PROXY_PROJECT_ID").expect("TEST_RPC_PROXY_PROJECT_ID must be set");
 
         std::thread::spawn(move || {
             rt.block_on(async move {


### PR DESCRIPTION
# Description

Solves recent problems with tests after zksync addition.
Renames PROJECT_ID to TEST_RPC_PROXY_PROJECT_ID to give it more context.
Mentions TEST_RPC_PROXY_PROJECT_ID in .env.example.


## How Has This Been Tested?

Integ tests ran locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
