### PR TITLE
feat: expose via backup DNS

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 4.4"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 4.4"
     }
   }
 }

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -148,3 +148,20 @@ resource "aws_route53_record" "dns_load_balancer" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "backup_dns_load_balancer" {
+  zone_id = var.backup_route53_zone_id
+  name    = var.backup_fqdn
+  type    = "A"
+
+  alias {
+    name                   = aws_alb.network_load_balancer.dns_name
+    zone_id                = aws_alb.network_load_balancer.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_lb_listener_certificate" "backup_cert" {
+  listener_arn    = aws_lb_listener.listener.arn
+  certificate_arn = var.backup_acm_certificate_arn
+}

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -30,6 +30,18 @@ variable "route53_zone_id" {
   type = string
 }
 
+variable "backup_acm_certificate_arn" {
+  type = string
+}
+
+variable "backup_fqdn" {
+  type = string
+}
+
+variable "backup_route53_zone_id" {
+  type = string
+}
+
 variable "infura_project_id" {
   type = string
 }

--- a/terraform/private_zone/main.tf
+++ b/terraform/private_zone/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 4.4"
     }
   }
 }

--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = "~> 4.4"
     }
   }
 }


### PR DESCRIPTION
# Description

Exposes the RPC via `.org` for frens who cannot access `.com` if it's blocked.

## How Has This Been Tested?

Tested in staging.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
