### PR TITLE
feat: moving metrics to private endpoint and better testing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       deploy_infra:
-        description: 'Whether to deploy infrastructure'
+        description: "Whether to deploy infrastructure"
         default: true
         required: true
         type: boolean
       deploy_app:
-        description: 'Whether to deploy app'
+        description: "Whether to deploy app"
         default: true
         required: true
         type: boolean
@@ -36,7 +36,7 @@ on:
 concurrency: cd
 
 env:
-  IMAGE_NAME: 'rpc-proxy'
+  IMAGE_NAME: "rpc-proxy"
   TF_VAR_infura_project_id: ${{ secrets.INFURA_PROJECT_ID }}
   TF_VAR_pokt_project_id: ${{ secrets.POKT_PROJECT_ID }}
   TF_VAR_registry_api_auth_token: ${{ secrets.REGISTRY_API_AUTH_TOKEN }}
@@ -94,17 +94,12 @@ jobs:
           task-definition-name: ${{ env.ENVIRONMENT }}_${{ env.IMAGE_NAME }}
           image-name: ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
-  validate:
+  validate_staging:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     needs: [deploy-app-staging, deploy-infra-staging]
-    runs-on: ubuntu-latest
-    environment:
-      name: app/staging
-      url: https://staging.rpc.walletconnect.com/hello
-    steps:
-      - name: validate
-        run: |
-          curl "https://staging.rpc.walletconnect.com/health"
+    uses: ./.github/workflows/validate.yml
+    with:
+      environment_url: "https://staging.rpc.walletconnect.com"
 
   deployment_windows:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
@@ -182,3 +177,10 @@ jobs:
           service-name: ${{ env.ENVIRONMENT }}_${{ env.IMAGE_NAME }}-service
           task-definition-name: ${{ env.ENVIRONMENT }}_${{ env.IMAGE_NAME }}
           image-name: ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+  validate_prod:
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    needs: [deploy-app-staging, deploy-infra-staging]
+    uses: ./.github/workflows/validate.yml
+    with:
+      environment_url: "https://rpc.walletconnect.com"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -97,7 +97,7 @@ jobs:
   validate_staging:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     needs: [deploy-app-staging, deploy-infra-staging]
-    uses: ./.github/workflows/validate.yml
+    uses: ./.github/workflows/validate.yaml
     with:
       environment_url: "https://staging.rpc.walletconnect.com"
 
@@ -181,6 +181,6 @@ jobs:
   validate_prod:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     needs: [deploy-app-staging, deploy-infra-staging]
-    uses: ./.github/workflows/validate.yml
+    uses: ./.github/workflows/validate.yaml
     with:
       environment_url: "https://rpc.walletconnect.com"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -103,7 +103,7 @@ jobs:
 
   deployment_windows:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
-    needs: [validate]
+    needs: [validate_staging]
     outputs:
       result: ${{ steps.decide.outputs.deploy_or_not }}
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -124,7 +124,7 @@ jobs:
     # Only deploy if tests passed and deployment windows are open
     # Ignore deployment windows if workflow was started manually
     if: ${{ always() && inputs.deploy_infra && needs.validate.result == 'success' && (needs.deployment_windows.outputs.result == 'yes' || github.event_name == 'workflow_dispatch') }}
-    needs: [validate, deployment_windows]
+    needs: [validate_staging, deployment_windows]
     runs-on: ubuntu-latest
     environment:
       name: infra/prod
@@ -151,7 +151,7 @@ jobs:
     # Only deploy if tests passed and deployment windows are open
     # Ignore deployment windows if workflow was started manually
     if: ${{ always() && inputs.deploy_app && needs.validate.result == 'success' && (needs.deployment_windows.outputs.result == 'yes' || github.event_name == 'workflow_dispatch') }}
-    needs: [validate, deployment_windows]
+    needs: [validate_staging, deployment_windows]
     runs-on: ubuntu-latest
     environment:
       name: app/prod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,22 +50,22 @@ jobs:
             rust: nightly
           - name: "Integration Tests: Pokt"
             cmd: test
-            args: --all-features -- functional::connection::pokt
+            args: --features test-localhost -- functional::connection::pokt
             cache: { sharedKey: "tests" }
             rust: stable
           - name: "Integration Tests: Infura"
             cmd: test
-            args: --all-features -- functional::connection::infura
+            args: --features test-localhost -- functional::connection::infura
             cache: { sharedKey: "tests" }
             rust: stable
           - name: "Integration Tests: Binance"
             cmd: test
-            args: --all-features -- functional::connection::binance
+            args: --features test-localhost -- functional::connection::binance
             cache: { sharedKey: "tests" }
             rust: stable
           - name: "Integration Tests: ZkSync"
             cmd: test
-            args: --all-features -- functional::connection::zksync
+            args: --features test-localhost -- functional::connection::zksync
             cache: { sharedKey: "tests" }
             rust: stable
         include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,24 +48,9 @@ jobs:
             args: -- --check
             cache: {}
             rust: nightly
-          - name: "Integration Tests: Pokt"
+          - name: "Functional Tests"
             cmd: test
             args: --features test-localhost -- functional::connection::pokt
-            cache: { sharedKey: "tests" }
-            rust: stable
-          - name: "Integration Tests: Infura"
-            cmd: test
-            args: --features test-localhost -- functional::connection::infura
-            cache: { sharedKey: "tests" }
-            rust: stable
-          - name: "Integration Tests: Binance"
-            cmd: test
-            args: --features test-localhost -- functional::connection::binance
-            cache: { sharedKey: "tests" }
-            rust: stable
-          - name: "Integration Tests: ZkSync"
-            cmd: test
-            args: --features test-localhost -- functional::connection::zksync
             cache: { sharedKey: "tests" }
             rust: stable
         include:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,34 @@
+name: validate
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "the environment to validate"
+        required: true
+        default: "staging"
+        type: choice
+        options:
+          - prod
+          - staging
+  workflow_call:
+    inputs:
+      environment:
+        description: "Environment to test"
+        required: true
+        default: "STAGING"
+        type: string
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run integration tests
+        run: cargo test --test integration
+        env:
+          PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          RPC_PROXY_INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+          RPC_PROXY_REGISTRY_API_URL: ${{ secrets.REGISTRY_URL }}
+          RPC_PROXY_REGISTRY_API_AUTH_TOKEN: ${{ secrets.RPC_PROXY_REGISTRY_API_AUTH_TOKEN }}
+          RPC_PROXY_POKT_PROJECT_ID: ${{ secrets.POKT_PROJECT_ID }}
+          RPC_URL: ${{ inputs.environment_url }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,7 +1,7 @@
 name: validate
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       environment_url:
         description: "the environment to validate"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,20 +3,10 @@ name: validate
 on:
   workflow_dispatch:
     inputs:
-      environment:
+      environment_url:
         description: "the environment to validate"
         required: true
-        default: "staging"
-        type: choice
-        options:
-          - prod
-          - staging
-  workflow_call:
-    inputs:
-      environment:
-        description: "Environment to test"
-        required: true
-        default: "STAGING"
+        default: "https://staging.rpc.walletconnect.com"
         type: string
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,6 @@ test-context = "0.1"
 
 [build-dependencies]
 vergen = { version = "6", default-features = false, features = ["build", "cargo", "git"] }
+
+[features]
+test-localhost = []

--- a/src/env/server.rs
+++ b/src/env/server.rs
@@ -9,8 +9,8 @@ use {
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
+    pub private_port: u16,
     pub log_level: String,
-
     pub external_ip: Option<IpAddr>,
 }
 
@@ -19,6 +19,7 @@ impl Default for ServerConfig {
         ServerConfig {
             host: "127.0.0.1".to_string(),
             port: 3000,
+            private_port: 4000,
             log_level: "INFO".to_string(),
             external_ip: None,
         }

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -113,7 +113,7 @@ resource "aws_ecs_task_definition" "app_task" {
       name : "aws-otel-collector",
       image : "public.ecr.aws/aws-observability/aws-otel-collector:latest",
       environment : [
-        { name : "AWS_PROMETHEUS_SCRAPING_ENDPOINT", value : "0.0.0.0:${var.port}" },
+        { name : "AWS_PROMETHEUS_SCRAPING_ENDPOINT", value : "0.0.0.0:${var.private_port}" },
         { name : "AWS_PROMETHEUS_ENDPOINT", value : "${var.prometheus_endpoint}api/v1/remote_write" }
       ],
       essential : true,

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -18,6 +18,10 @@ variable "port" {
   type = number
 }
 
+variable "private_port" {
+  type = number
+}
+
 variable "acm_certificate_arn" {
   type = string
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,6 +57,7 @@ module "ecs" {
   region                     = var.region
   vpc_name                   = "ops-${terraform.workspace}-vpc"
   port                       = 3000
+  private_port               = 4000
   acm_certificate_arn        = module.dns.certificate_arn
   fqdn                       = local.fqdn
   route53_zone_id            = module.dns.zone_id

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -1,4 +1,4 @@
-use {self::server::RpcProxy, async_trait::async_trait, test_context::AsyncTestContext};
+use {self::server::RpcProxy, async_trait::async_trait, std::env, test_context::AsyncTestContext};
 
 mod server;
 
@@ -9,11 +9,32 @@ pub struct ServerContext {
 #[async_trait]
 impl AsyncTestContext for ServerContext {
     async fn setup() -> Self {
+        #[cfg(feature = "test-localhost")]
         let server = RpcProxy::start().await;
+
+        #[cfg(not(feature = "test-localhost"))]
+        let server = {
+            let public_addr =
+                env::var("RPC_URL").unwrap_or("https://staging.rpc.walletconnect.com".to_owned());
+
+            {
+                let project_id = env::var("PROJECT_ID").expect("PROJECT_ID must be set");
+                RpcProxy {
+                    private_addr: None,
+                    public_port: None,
+                    public_addr,
+                    project_id,
+                    shutdown_signal: None,
+                    is_shutdown: false,
+                }
+            }
+        };
+
         Self { server }
     }
 
     async fn teardown(mut self) {
+        #[cfg(feature = "test-localhost")]
         self.server.shutdown().await;
     }
 }

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -59,7 +59,7 @@ impl RpcProxy {
         }
 
         Self {
-            public_addr: public_addr.to_string(),
+            public_addr: format!("http://{}", public_addr),
             project_id,
             shutdown_signal: Some(signal),
             is_shutdown: false,

--- a/tests/functional/connection/binance.rs
+++ b/tests/functional/connection/binance.rs
@@ -9,7 +9,7 @@ use {
 #[tokio::test]
 async fn eip155_56_bsc_mainnet(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1/?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -37,7 +37,7 @@ async fn eip155_56_bsc_mainnet(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_97_bsc_testnet(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1/?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 

--- a/tests/functional/connection/infura.rs
+++ b/tests/functional/connection/infura.rs
@@ -5,7 +5,7 @@ use {
         utils::send_jsonrpc_request,
         JSONRPC_VERSION,
     },
-    hyper::{http, Body, Client, Method, Request, StatusCode},
+    hyper::{Body, Client, Method, Request, StatusCode},
     hyper_tls::HttpsConnector,
     test_context::test_context,
 };
@@ -13,7 +13,7 @@ use {
 #[test_context(ServerContext)]
 #[tokio::test]
 async fn health_check(ctx: &mut ServerContext) {
-    let addr = format!("http://{}/health", ctx.server.public_addr);
+    let addr = format!("{}/health", ctx.server.public_addr);
 
     let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
 
@@ -30,27 +30,9 @@ async fn health_check(ctx: &mut ServerContext) {
 
 #[test_context(ServerContext)]
 #[tokio::test]
-async fn metrics_check(ctx: &mut ServerContext) {
-    let addr = format!("htpps://{}/metrics", ctx.server.public_addr);
-
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
-
-    let request = Request::builder()
-        .method(Method::GET)
-        .uri(addr)
-        .body(Body::default())
-        .unwrap();
-
-    let response = client.request(request).await.unwrap();
-
-    assert_eq!(response.status(), http::StatusCode::OK)
-}
-
-#[test_context(ServerContext)]
-#[tokio::test]
 async fn eip155_1_mainnet_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -78,7 +60,7 @@ async fn eip155_1_mainnet_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_3_ropsten_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -108,7 +90,7 @@ async fn eip155_3_ropsten_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_42_kovan_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -137,7 +119,7 @@ async fn eip155_42_kovan_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_4_rinkeby_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -166,7 +148,7 @@ async fn eip155_4_rinkeby_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_5_goerli_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -194,7 +176,7 @@ async fn eip155_5_goerli_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_137_polygon_mainnet_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -222,7 +204,7 @@ async fn eip155_137_polygon_mainnet_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_80001_polygon_mumbai_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -250,7 +232,7 @@ async fn eip155_80001_polygon_mumbai_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_10_optimism_mainnet_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -278,7 +260,7 @@ async fn eip155_10_optimism_mainnet_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_69_optimism_kovan_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -307,7 +289,7 @@ async fn eip155_69_optimism_kovan_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_420_optimism_goerli_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -335,7 +317,7 @@ async fn eip155_420_optimism_goerli_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_42161_arbitrum_mainnet_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -363,7 +345,7 @@ async fn eip155_42161_arbitrum_mainnet_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_421611_arbitrum_rinkeby_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -392,7 +374,7 @@ async fn eip155_421611_arbitrum_rinkeby_infura(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_421613_arbitrum_goerli_infura(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 

--- a/tests/functional/connection/pokt.rs
+++ b/tests/functional/connection/pokt.rs
@@ -9,7 +9,7 @@ use {
 #[tokio::test]
 async fn eip155_43114_avax(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -37,7 +37,7 @@ async fn eip155_43114_avax(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_100_gnosis(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -65,7 +65,7 @@ async fn eip155_100_gnosis(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn solana_mainnet(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 

--- a/tests/functional/connection/zksync.rs
+++ b/tests/functional/connection/zksync.rs
@@ -9,7 +9,7 @@ use {
 #[tokio::test]
 async fn eip155_324_zksync_mainnet(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 
@@ -37,7 +37,7 @@ async fn eip155_324_zksync_mainnet(ctx: &mut ServerContext) {
 #[tokio::test]
 async fn eip155_280_zksync_testnet(ctx: &mut ServerContext) {
     let addr = format!(
-        "http://{}/v1?projectId={}&chainId=",
+        "{}/v1?projectId={}&chainId=",
         ctx.server.public_addr, ctx.server.project_id
     );
 

--- a/tests/functional/metrics.rs
+++ b/tests/functional/metrics.rs
@@ -1,0 +1,18 @@
+#[cfg(feature = "test-localhost")]
+#[test_context(ServerContext)]
+#[tokio::test]
+async fn metrics_check(ctx: &mut ServerContext) {
+    let addr = format!("https://{}/metrics", ctx.server.private_addr.unwrap());
+
+    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(addr)
+        .body(Body::default())
+        .unwrap();
+
+    let response = client.request(request).await.unwrap();
+
+    assert_eq!(response.status(), http::StatusCode::OK)
+}


### PR DESCRIPTION
# Description

Moving metrics to private endpoint for prometheus. 
Also integ testing on staging and prod. 
Changed tests to use `/v1/` endpoint to track the issue we had recently.

With all comments addressed.

Resolves #81  and #99 

## How Has This Been Tested?

Integ tests. Will require manual verificaiton.


## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
