### PR TITLE
fix: change string to array for proper parsing

### DIFF
--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -13,8 +13,8 @@ locals {
   opsgenie_notification_channel = "l_iaPw6nk"
   notifications = (
     var.environment == "prod" ?
-    "[{\"uid\": \"${local.opsgenie_notification_channel}\"}]" :
-    "[]"
+    [{"uid": "${local.opsgenie_notification_channel}"}] :
+    []
   )
 
   target_group  = split(":", var.target_group_arn)[5]

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -13,7 +13,7 @@ locals {
   opsgenie_notification_channel = "l_iaPw6nk"
   notifications = (
     var.environment == "prod" ?
-    [{"uid": "${local.opsgenie_notification_channel}"}] :
+    [{ "uid" : "${local.opsgenie_notification_channel}" }] :
     []
   )
 

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -13,7 +13,7 @@ locals {
   opsgenie_notification_channel = "l_iaPw6nk"
   notifications = (
     var.environment == "prod" ?
-    [{ "uid" : "${local.opsgenie_notification_channel}" }] :
+    [{ uid = local.opsgenie_notification_channel }] :
     []
   )
 
@@ -1436,7 +1436,7 @@ resource "grafana_dashboard" "at_a_glance" {
                 "uid" : grafana_data_source.cloudwatch.uid
               },
               "dimensions" : {
-                "TargetGroup" : "${local.target_group}"
+                "TargetGroup" : local.target_group
               },
               "expression" : "",
               "id" : "",
@@ -1472,7 +1472,7 @@ resource "grafana_dashboard" "at_a_glance" {
                     {
                       "operator" : {
                         "name" : "=",
-                        "value" : "${local.load_balancer}"
+                        "value" : local.load_balancer
                       },
                       "property" : {
                         "name" : "LoadBalancer",


### PR DESCRIPTION
# Description

Terraform was not parsing the string with notification configuration we were providing, later escaping it when putting it in json. I lead to broken connection grafana <-> opsgenie. Changed string to array so it is properly encoded in json.

Resolves #112 

## How Has This Been Tested?

Deployed to staging.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
