### PR TITLE
fix: remove polygon ws - no longer supported by infura 

### DIFF
--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -27,6 +27,9 @@ fn default_infura_supported_chains() -> HashMap<String, String> {
         ("eip155:42161".into(), "arbitrum-mainnet".into()),
         ("eip155:421611".into(), "arbitrum-rinkeby".into()),
         ("eip155:421613".into(), "arbitrum-goerli".into()),
+        // Polygon
+        ("eip155:137".into(), "polygon-mainnet".into()),
+        ("eip155:80001".into(), "polygon-mumbai".into()),
         // Celo
         ("eip155:42220".into(), "celo-mainnet".into()),
         // Aurora
@@ -43,9 +46,6 @@ fn default_infura_ws_supported_chains() -> HashMap<String, String> {
         ("eip155:42".into(), "kovan".into()),
         ("eip155:4".into(), "rinkeby".into()),
         ("eip155:5".into(), "goerli".into()),
-        // Polygon
-        ("eip155:137".into(), "polygon-mainnet".into()),
-        ("eip155:80001".into(), "polygon-mumbai".into()),
         // Optimism
         ("eip155:10".into(), "optimism-mainnet".into()),
         ("eip155:69".into(), "optimism-kovan".into()),

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -19,9 +19,6 @@ fn default_infura_supported_chains() -> HashMap<String, String> {
         ("eip155:42".into(), "kovan".into()),
         ("eip155:4".into(), "rinkeby".into()),
         ("eip155:5".into(), "goerli".into()),
-        // Polygon
-        ("eip155:137".into(), "polygon-mainnet".into()),
-        ("eip155:80001".into(), "polygon-mumbai".into()),
         // Optimism
         ("eip155:10".into(), "optimism-mainnet".into()),
         ("eip155:69".into(), "optimism-kovan".into()),

--- a/tests/functional/websocket/infura.rs
+++ b/tests/functional/websocket/infura.rs
@@ -39,18 +39,6 @@ async fn eip155_5_goerli_infura(ctx: &mut ServerContext) {
 
 #[test_context(ServerContext)]
 #[tokio::test]
-async fn eip155_137_polygon_mainnet_infura(ctx: &mut ServerContext) {
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:137", "0x89").await
-}
-
-#[test_context(ServerContext)]
-#[tokio::test]
-async fn eip155_80001_polygon_mumbai_infura(ctx: &mut ServerContext) {
-    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:80001", "0x13881").await
-}
-
-#[test_context(ServerContext)]
-#[tokio::test]
 async fn eip155_10_optimism_mainnet_infura(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:10", "0xa").await
 }


### PR DESCRIPTION
# Description

Infura restricted ws functionality for polygon rendering it currently not useful for our proxy purposed. Removing it for now. We still support it over HTTP.

## How Has This Been Tested?

Failing tests lead to contact with infura and information from them.
Now tests pass.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
