### PR TITLE
feat: distinguish between provider and service errors

### DIFF
--- a/src/analytics/message_info.rs
+++ b/src/analytics/message_info.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{handlers::RpcQueryParams, json_rpc::JsonRpcRequest},
+    crate::{handlers::RpcQueryParams, json_rpc::JsonRpcRequest, providers::ProviderKind},
     parquet_derive::ParquetRecordWriter,
     serde::Serialize,
     std::sync::Arc,
@@ -14,6 +14,8 @@ pub struct MessageInfo {
     pub chain_id: String,
     pub method: Arc<str>,
 
+    pub provider: String,
+
     pub region: Option<String>,
     pub country: Option<Arc<str>>,
     pub continent: Option<Arc<str>>,
@@ -26,6 +28,7 @@ impl MessageInfo {
         region: Option<Vec<String>>,
         country: Option<Arc<str>>,
         continent: Option<Arc<str>>,
+        provider: ProviderKind,
     ) -> Self {
         Self {
             timestamp: gorgon::time::now(),
@@ -33,6 +36,8 @@ impl MessageInfo {
             project_id: query_params.project_id.to_owned(),
             chain_id: query_params.chain_id.to_lowercase(),
             method: request.method.clone(),
+
+            provider: provider.to_string(),
 
             region: region.map(|r| r.join(", ")),
             country,

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -9,7 +9,7 @@ use {
     axum::{
         body::Bytes,
         extract::{ConnectInfo, MatchedPath, Query, State},
-        response::{IntoResponse, Response},
+        response::Response,
     },
     hyper::{http, HeaderMap},
     std::{
@@ -71,7 +71,7 @@ pub async fn handler(
     // Start timing external provider added time
     let external_call_start = SystemTime::now();
 
-    let response = provider
+    let mut response = provider
         .proxy(method, path, query_params, headers, body)
         .await
         .map_err(|error| {
@@ -92,22 +92,19 @@ pub async fn handler(
             .as_secs_f64(),
     );
 
-    let response = match response.status() {
+    match response.status() {
         http::StatusCode::OK => {
             state.metrics.add_finished_provider_call(provider.borrow());
-            response
         }
         status => {
             state.metrics.add_failed_provider_call(provider.borrow());
             state
                 .metrics
                 .add_status_code_for_provider(provider.borrow(), status);
-            let (mut parts, body) = response.into_parts();
-            parts.status = http::StatusCode::BAD_GATEWAY;
 
-            Response::from_parts(parts, body)
+            *response.status_mut() = http::StatusCode::BAD_GATEWAY;
         }
     };
 
-    Ok(response.into_response())
+    Ok(response)
 }


### PR DESCRIPTION
# Description

Added more metrics to track both how many calls are successful and how many fail per provider, as well as status codes per provider.

Also added `provider` to data lake exports.

Resolves #122 

## How Has This Been Tested?

This is initial work in the subject, currently tested by running locally and forcing two kinds of error: in the service and in the provider, with the following result

```
curl -X POST \
  'http:///localhost:3000/v1/?projectId=<project_id>3&chainId=eip155:2' \
  --header 'Content-Type: application/json' \
  --data-raw '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
```
where eip155:2 is not supported -> results in: 
```
400 BAD REQUEST
{
  "status": "FAILED",
  "reasons": [
    {
      "field": "chainId",
      "description": "We don't support the chainId you provided: eip155:2"
    }
  ]
}
```

while 
```
curl -X POST \
  'http:///localhost:3000/v1/?projectId=<project_id>&chainId=eip155:1' \
  --header 'Content-Type: application/json' \
  --data-raw '{ "invalid":"json" }'
```
returns 

```
502 BAD GATEWAY

{
  "jsonrpc": "2.0",
  "error": {
    "code": -32600,
    "message": "invalid json request"
  }
}
```

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
