### PR TITLE
fix: fixed tests in ci workflow, changed expected response to match r…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
             rust: nightly
           - name: "Functional Tests"
             cmd: test
-            args: --features test-localhost -- functional::connection::pokt
+            args: --features test-localhost
             cache: { sharedKey: "tests" }
             rust: stable
         include:

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -62,7 +62,7 @@ async fn check_if_rpc_is_responding_correctly_for_decomissioned(
     let (status, rpc_response) = send_jsonrpc_request(client, addr, chaind_id, request).await;
 
     // Verify that HTTP communication returns error
-    assert_eq!(status, StatusCode::GONE);
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
 
     // Verify the error code is for
     // "Network decommissioned, please use Goerli or Sepolia instead"


### PR DESCRIPTION
# Description

Previous commit changed the status code returned when provider fails, but didn't update  tests. Tests were called improperly in workflow which led to this being missed untill another workflow ran and failed.

Changing the tests to match the changes and fixing the workflow.


## How Has This Been Tested?

Tests ran locally - passing

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
