### PR TITLE
fix: return 401 instead of 500 for unauthorized

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use {
     axum::{response::IntoResponse, Json},
     cerberus::registry::RegistryError,
     hyper::StatusCode,
-    tracing::log::error,
+    tracing::log::{error, warn},
 };
 
 pub type RpcResult<T> = Result<T, RpcError>;
@@ -82,7 +82,14 @@ impl IntoResponse for RpcError {
                 "Invalid scheme used. Try http(s):// or ws(s)://".to_string(),
             )
                 .into_response(),
-
+            Self::RegistryError(e) => {
+                warn!("Registry error: {:?}", e);
+                (
+                    StatusCode::UNAUTHORIZED,
+                    "We failed to authenticate your request".to_string(),
+                )
+                    .into_response()
+            }
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal server error".to_string(),


### PR DESCRIPTION
# Description

When provided with an invalid project id, the service would return 500 instead of 401.
Not it will return proper error to user, as well as leaving log for us to investigate if needed.

## How Has This Been Tested?

Ran and verified locally.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
