### PR TITLE
fix: remove decomissioned chains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,4 @@ vergen = { version = "6", default-features = false, features = ["build", "cargo"
 
 [features]
 test-localhost = []
+dynamic-weights = []

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -33,9 +33,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     HashMap::from([
         // Ethereum
         ("eip155:1".into(), ("mainnet".into(), Weight(10.into()))),
-        ("eip155:3".into(), ("ropsten".into(), Weight(1.into()))),
-        ("eip155:42".into(), ("kovan".into(), Weight(1.into()))),
-        ("eip155:4".into(), ("rinkeby".into(), Weight(1.into()))),
         ("eip155:5".into(), ("goerli".into(), Weight(1.into()))),
         // Optimism
         (
@@ -54,10 +51,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:42161".into(),
             ("arbitrum-mainnet".into(), Weight(1.into())),
-        ),
-        (
-            "eip155:421611".into(),
-            ("arbitrum-rinkeby".into(), Weight(1.into())),
         ),
         (
             "eip155:421613".into(),
@@ -93,9 +86,6 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
     HashMap::from([
         // Ethereum
         ("eip155:1".into(), ("mainnet".into(), Weight(1.into()))),
-        ("eip155:3".into(), ("ropsten".into(), Weight(1.into()))),
-        ("eip155:42".into(), ("kovan".into(), Weight(1.into()))),
-        ("eip155:4".into(), ("rinkeby".into(), Weight(1.into()))),
         ("eip155:5".into(), ("goerli".into(), Weight(1.into()))),
         // Optimism
         (
@@ -114,10 +104,6 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:42161".into(),
             ("arbitrum-mainnet".into(), Weight(1.into())),
-        ),
-        (
-            "eip155:421611".into(),
-            ("arbitrum-rinkeby".into(), Weight(1.into())),
         ),
         (
             "eip155:421613".into(),

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -34,7 +34,6 @@ pub struct Config {
     pub registry: RegistryConfig,
     pub storage: StorageConfig,
     pub analytics: AnalyticsConfig,
-    pub prometheus_query_url: String,
 }
 
 impl Config {
@@ -44,8 +43,6 @@ impl Config {
             registry: from_env("RPC_PROXY_REGISTRY_")?,
             storage: from_env("RPC_PROXY_STORAGE_")?,
             analytics: from_env("RPC_PROXY_ANALYTICS_")?,
-            prometheus_query_url: std::env::var("PROMETHEUS_QUERY_URL")
-                .unwrap_or("http://localhost:9090".into()),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,29 +151,22 @@ pub async fn bootstrap(mut shutdown: broadcast::Receiver<()>, config: Config) ->
         .route("/metrics", get(handlers::metrics::handler))
         .with_state(state_arc.clone());
 
-    #[cfg(feature = "dynamic-weights")]
-    {
-        let updater = tokio::task::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(15));
-            loop {
-                interval.tick().await;
-                state_arc.update_provider_weights().await;
-            }
-        });
+    let public_server =
+        axum::Server::bind(&addr).serve(app.into_make_service_with_connect_info::<SocketAddr>());
 
-        select! {
-            _ = shutdown.recv() => info!("Shutdown signal received, killing servers"),
-            _ = axum::Server::bind(&private_addr).serve(private_app.into_make_service()) => info!("Private server terminating"),
-            _ = axum::Server::bind(&addr).serve(app.into_make_service_with_connect_info::<SocketAddr>()) => info!("Server terminating"),
-            _ = updater => info!("Updater terminating")
-        }
-    }
+    let private_server = axum::Server::bind(&private_addr)
+        .serve(private_app.into_make_service_with_connect_info::<SocketAddr>());
 
-    #[cfg(not(feature = "dynamic-weights"))]
+    let services = vec![
+        tokio::spawn(public_server),
+        tokio::spawn(private_server),
+        #[cfg(feature = "dynamic-weights")]
+        tokio::spawn(updater),
+    ];
+
     select! {
         _ = shutdown.recv() => info!("Shutdown signal received, killing servers"),
-        _ = axum::Server::bind(&private_addr).serve(private_app.into_make_service()) => info!("Private server terminating"),
-        _ = axum::Server::bind(&addr).serve(app.into_make_service_with_connect_info::<SocketAddr>()) => info!("Server terminating"),
+        e =  futures_util::future::select_all(services) => info!("Server terminating with error: {:?}", e),
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub async fn bootstrap(mut shutdown: broadcast::Receiver<()>, config: Config) ->
 }
 
 fn init_providers() -> ProviderRepository {
-    let mut providers = ProviderRepository::default();
+    let mut providers = ProviderRepository::new();
 
     #[cfg(feature = "dynamic-weights")]
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,12 @@ use {
     dotenv::dotenv,
     rpc_proxy::{env::Config, error},
     std::str::FromStr,
-    tokio::sync::broadcast,
     tracing_subscriber::fmt::format::FmtSpan,
 };
 
 #[tokio::main]
 async fn main() -> error::RpcResult<()> {
     dotenv().ok();
-
-    let (_signal, shutdown) = broadcast::channel(1);
 
     let config = Config::from_env()
         .map_err(|e| dbg!(e))
@@ -24,5 +21,5 @@ async fn main() -> error::RpcResult<()> {
         .with_ansi(false)
         .init();
 
-    rpc_proxy::bootstrap(shutdown, config).await
+    rpc_proxy::bootstrap(config).await
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,7 +4,7 @@ use {
     opentelemetry::metrics::{Counter, Meter, ValueRecorder},
 };
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Metrics {
     pub rpc_call_counter: Counter<u64>,
     pub http_call_counter: Counter<u64>,
@@ -155,6 +155,7 @@ impl Metrics {
         ])
     }
 
+    #[cfg(feature = "dynamic-weights")]
     pub fn record_provider_weight(&self, provider: &ProviderKind, chain_id: &str, weight: u64) {
         self.weights_value_recorder.record(weight, &[
             opentelemetry::KeyValue::new("provider", provider.to_string()),

--- a/src/providers/weights.rs
+++ b/src/providers/weights.rs
@@ -175,6 +175,6 @@ mod tests {
         let weight = super::calculate_chain_weight(chain_availability, &provider_availabilities);
 
         // 100% * 100% = 100%
-        assert_eq!(weight, 100_00);
+        assert_eq!(weight, 10_000);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,32 +8,28 @@ use {
         utils::build::CompileInfo,
     },
     opentelemetry_prometheus::PrometheusExporter,
+    std::sync::Arc,
 };
 
 pub struct AppState {
     pub config: Config,
     pub providers: ProviderRepository,
     pub exporter: PrometheusExporter,
-    pub metrics: Metrics,
+    pub metrics: Arc<Metrics>,
     pub registry: Registry,
     pub analytics: RPCAnalytics,
     pub compile_info: CompileInfo,
-    pub prometheus_client: prometheus_http_query::Client,
 }
 
 pub fn new_state(
     config: Config,
     providers: ProviderRepository,
     exporter: PrometheusExporter,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
     registry: Registry,
     analytics: RPCAnalytics,
 ) -> AppState {
-    let client = prometheus_http_query::Client::try_from(config.prometheus_query_url.clone())
-        .expect("Failed to connect to prometheus");
-
     AppState {
-        prometheus_client: client,
         config,
         providers,
         exporter,
@@ -45,6 +41,7 @@ pub fn new_state(
 }
 
 impl AppState {
+    #[cfg(feature = "dynamic-weights")]
     pub async fn update_provider_weights(&self) {
         self.providers.update_weights(&self.metrics).await;
     }

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -35,11 +35,6 @@ impl AsyncTestContext for ServerContext {
 
         Self { server }
     }
-
-    async fn teardown(mut self) {
-        #[cfg(feature = "test-localhost")]
-        self.server.shutdown().await;
-    }
 }
 
 pub type TestResult<T> = Result<T, TestError>;

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -27,8 +27,6 @@ impl AsyncTestContext for ServerContext {
                     public_port: None,
                     public_addr,
                     project_id,
-                    shutdown_signal: None,
-                    is_shutdown: false,
                 }
             }
         };

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -1,13 +1,13 @@
-use {
-    super::TestResult,
-    std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream},
-    tokio::time::{sleep, Duration},
-};
+use std::net::SocketAddr;
+
 #[cfg(feature = "test-localhost")]
 use {
+    super::TestResult,
     rpc_proxy::env::{Config, ServerConfig},
+    std::net::{Ipv4Addr, SocketAddrV4, TcpStream},
+    std::time::Duration,
     std::{env, net::IpAddr},
-    tokio::{runtime::Handle, sync::broadcast},
+    tokio::{runtime::Handle, time::sleep},
 };
 
 pub struct RpcProxy {
@@ -15,8 +15,6 @@ pub struct RpcProxy {
     pub public_port: Option<u16>,
     pub private_addr: Option<SocketAddr>,
     pub project_id: String,
-    pub shutdown_signal: Option<tokio::sync::broadcast::Sender<()>>,
-    pub is_shutdown: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -31,8 +29,6 @@ impl RpcProxy {
         let rt = Handle::current();
         let public_addr = SocketAddr::new(IpAddr::V4(hostname), public_port);
         let private_addr = SocketAddr::new(IpAddr::V4(hostname), private_port);
-
-        let (signal, shutdown) = broadcast::channel(1);
 
         let project_id =
             env::var("TEST_RPC_PROXY_PROJECT_ID").expect("TEST_RPC_PROXY_PROJECT_ID must be set");
@@ -60,8 +56,6 @@ impl RpcProxy {
         Self {
             public_addr: format!("http://{public_addr}"),
             project_id,
-            shutdown_signal: Some(signal),
-            is_shutdown: false,
             private_addr: Some(private_addr),
             public_port: Some(public_port),
         }
@@ -84,19 +78,9 @@ fn get_random_port() -> u16 {
     }
 }
 
+#[cfg(feature = "test-localhost")]
 fn is_port_available(port: u16) -> bool {
     TcpStream::connect(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)).is_err()
-}
-
-#[allow(unused)]
-async fn wait_for_server_to_shutdown(port: u16) -> TestResult<()> {
-    let poll_fut = async {
-        while !is_port_available(port) {
-            sleep(Duration::from_millis(10)).await;
-        }
-    };
-
-    Ok(tokio::time::timeout(Duration::from_secs(1), poll_fut).await?)
 }
 
 #[cfg(feature = "test-localhost")]

--- a/tests/context/server.rs
+++ b/tests/context/server.rs
@@ -48,7 +48,7 @@ impl RpcProxy {
                     ..Default::default()
                 };
 
-                rpc_proxy::bootstrap(shutdown, config).await
+                rpc_proxy::bootstrap(config).await
             })
             .unwrap();
         });
@@ -65,19 +65,6 @@ impl RpcProxy {
             private_addr: Some(private_addr),
             public_port: Some(public_port),
         }
-    }
-
-    #[cfg(feature = "test-localhost")]
-    pub async fn shutdown(&mut self) {
-        if self.is_shutdown {
-            return;
-        }
-        self.is_shutdown = true;
-        let sender = self.shutdown_signal.clone();
-        let _ = sender.unwrap().send(());
-        wait_for_server_to_shutdown(self.public_port.unwrap())
-            .await
-            .unwrap();
     }
 }
 
@@ -109,7 +96,7 @@ async fn wait_for_server_to_shutdown(port: u16) -> TestResult<()> {
         }
     };
 
-    Ok(tokio::time::timeout(Duration::from_secs(3), poll_fut).await?)
+    Ok(tokio::time::timeout(Duration::from_secs(1), poll_fut).await?)
 }
 
 #[cfg(feature = "test-localhost")]

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        check_if_rpc_is_responding_correctly_for_decomissioned,
-        check_if_rpc_is_responding_correctly_for_supported_chain,
-    },
+    super::check_if_rpc_is_responding_correctly_for_supported_chain,
     crate::context::ServerContext,
     test_context::test_context,
 };
@@ -11,54 +8,27 @@ use {
 #[tokio::test]
 async fn infura_provider(ctx: &mut ServerContext) {
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:1", "0x1").await;
-    dbg!("Done with eip155:1");
-
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:3").await;
-    dbg!("Done with eip155:3");
-
-    // Kovan - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:42").await;
-    dbg!("Done with eip155:42");
-
-    // Rinkeby - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:4").await;
-    dbg!("Done with eip155:4");
 
     // Goerli mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:5", "0x5").await;
-    dbg!("Done with eip155:5");
 
     // Polgyon mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:137", "0x89").await;
-    dbg!("Done with eip155:137");
 
     // Polygon mumbai
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:80001", "0x13881").await;
-    dbg!("Done with eip155:80001");
 
     // Optimism mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:10", "0xa").await;
-    dbg!("Done with eip155:10");
-
-    // Optimism kovan - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:69").await;
-    dbg!("Done with eip155:69");
 
     // Optimism goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:420", "0x1A4").await;
-    dbg!("Done with eip155:420");
 
     // Arbitrum mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42161", "0xa4b1").await;
-    dbg!("Done with eip155:42161");
-
-    // Arbitrum rinkeby - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:421611").await;
-    dbg!("Done with eip155:421611");
 
     // Arbitrum goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:421613", "0x66eed").await;
-    dbg!("Done with eip155:421613");
 
     // Aurora mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
@@ -67,7 +37,6 @@ async fn infura_provider(ctx: &mut ServerContext) {
         "0x4e454152",
     )
     .await;
-    dbg!("Done with eip155:1313161554");
 
     // Aurora testnet
     check_if_rpc_is_responding_correctly_for_supported_chain(
@@ -76,5 +45,4 @@ async fn infura_provider(ctx: &mut ServerContext) {
         "0x4e454153",
     )
     .await;
-    dbg!("Done with eip155:1313161555");
 }

--- a/tests/functional/http/mod.rs
+++ b/tests/functional/http/mod.rs
@@ -10,8 +10,6 @@ pub(crate) mod infura;
 pub(crate) mod pokt;
 pub(crate) mod zksync;
 
-const INFURA_CHAIN_DECOMISSIONED_ERROR_CODE: i32 = -32601;
-
 async fn check_if_rpc_is_responding_correctly_for_supported_chain(
     ctx: &mut ServerContext,
     chaind_id: &str,
@@ -40,36 +38,6 @@ async fn check_if_rpc_is_responding_correctly_for_supported_chain(
 
     // Check chainId
     assert_eq!(rpc_response.result::<String>().unwrap(), expected_id)
-}
-
-async fn check_if_rpc_is_responding_correctly_for_decomissioned(
-    ctx: &mut ServerContext,
-    chaind_id: &str,
-) {
-    let addr = format!(
-        "{}/v1?projectId={}&chainId=",
-        ctx.server.public_addr, ctx.server.project_id
-    );
-
-    let client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
-    let request = jsonrpc::Request {
-        method: "eth_chainId",
-        params: &[],
-        id: serde_json::Value::Number(1.into()),
-        jsonrpc: JSONRPC_VERSION,
-    };
-
-    let (status, rpc_response) = send_jsonrpc_request(client, addr, chaind_id, request).await;
-
-    // Verify that HTTP communication returns error
-    assert_eq!(status, StatusCode::BAD_GATEWAY);
-
-    // Verify the error code is for
-    // "Network decommissioned, please use Goerli or Sepolia instead"
-    assert_eq!(
-        rpc_response.error.unwrap().code,
-        INFURA_CHAIN_DECOMISSIONED_ERROR_CODE
-    );
 }
 
 #[test_context(ServerContext)]

--- a/tests/functional/websocket/infura.rs
+++ b/tests/functional/websocket/infura.rs
@@ -1,8 +1,5 @@
 use {
-    super::{
-        check_if_rpc_is_responding_correctly_for_decomissioned,
-        check_if_rpc_is_responding_correctly_for_supported_chain,
-    },
+    super::check_if_rpc_is_responding_correctly_for_supported_chain,
     crate::context::ServerContext,
     test_context::test_context,
 };
@@ -13,32 +10,17 @@ async fn infura_websocket_provider(ctx: &mut ServerContext) {
     // Ethereum mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:1", "0x1").await;
 
-    // Ropsten - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:3").await;
-
-    // Kovan - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:42").await;
-
-    // Rinkeby - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:4").await;
-
     // Goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:5", "0x5").await;
 
     // Optimism mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:10", "0xa").await;
 
-    // Optimism kovan - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:69").await;
-
     // Optimism goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:420", "0x1A4").await;
 
     // Arbitrum mainnet
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:42161", "0xa4b1").await;
-
-    // Arbitrum rinkeby - decomissioned
-    check_if_rpc_is_responding_correctly_for_decomissioned(ctx, "eip155:421611").await;
 
     // Arbitrum goerli
     check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:421613", "0x66eed").await;

--- a/tests/functional/websocket/mod.rs
+++ b/tests/functional/websocket/mod.rs
@@ -41,23 +41,3 @@ async fn check_if_rpc_is_responding_correctly_for_supported_chain(
         format!("\"{expected_id}\"")
     );
 }
-
-async fn check_if_rpc_is_responding_correctly_for_decomissioned(
-    ctx: &mut ServerContext,
-    chain_id: &str,
-) {
-    let addr = format!(
-        "{}/ws?projectId={}&chainId={}",
-        ctx.server.public_addr, ctx.server.project_id, chain_id
-    )
-    .replace("http", "ws");
-
-    let client = async_tungstenite::tokio::connect_async(addr).await;
-    let err = client.err().unwrap();
-    if let axum_tungstenite::Error::Http(resp) = err {
-        // This chain is no longer supported
-        assert_eq!(resp.status(), hyper::StatusCode::GONE);
-    } else {
-        panic!("Invalid response")
-    }
-}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -25,6 +25,5 @@ pub async fn send_jsonrpc_request(
 
     let (parts, body) = response.into_parts();
     let body = body::to_bytes(body).await.unwrap();
-    dbg!(std::str::from_utf8(&body).unwrap());
     (parts.status, serde_json::from_slice(&body).unwrap())
 }


### PR DESCRIPTION
# Description

I was investigating why the tests are failing so oftenly, I though it was because half-baked system. Turns out Infura changed their handling of one decomissioned chain (from proper error to forbidden).

I think it's good idea to get rid of decomissioned chains. This way instead of giving strange error to user, we just inform them we don't support this chain with our message.


## How Has This Been Tested?

Ran tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
