### PR TITLE
fix: change response on provider rate limit from 400 to 502

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -86,13 +86,12 @@ pub async fn handler(
     let mut response = provider
         .proxy(method, path, query_params, headers, body)
         .await
-        .map_err(|error| {
+        .tap_err(|error| {
             if let RpcError::Throttled = error {
                 state
                     .metrics
                     .add_rate_limited_call(provider.borrow(), project_id)
             }
-            RpcError::ProviderError
         })?;
 
     state.metrics.add_external_http_latency(

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -35,6 +35,7 @@ impl AsyncTestContext for ServerContext {
     }
 }
 
+#[cfg(feature = "test-localhost")]
 pub type TestResult<T> = Result<T, TestError>;
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
# Description

Bugfix - wrong error code being returned to users on provider failure

## How Has This Been Tested?

Verified locally with custom provider.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
