### PR TITLE
fix: enable image version selection in cd

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -42,6 +42,11 @@ on:
         default: true 
         required: true
         type: boolean
+      image_version:
+          description: "Image version"
+          required: false 
+          type: string
+          default: "latest"
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -13,16 +13,16 @@ on:
         default: true
         required: true
         type: boolean
-      deploy_staging:
-        description: "Deploy staging"
-        default: true
-        required: true
-        type: boolean
       deploy_production:
         description: "Deploy production"
         default: false 
         required: true
         type: boolean
+      image_version:
+        description: "Image version"
+        required: false 
+        type: string
+        default: "latest"
 
   workflow_call:
     inputs:
@@ -64,7 +64,7 @@ env:
 
 jobs:
   deploy-infra-staging:
-    if: ${{ inputs.deploy_infra && inputs.deploy_staging }}
+    if: ${{ inputs.deploy_infra }}
     runs-on: ubuntu-latest
     environment:
       name: infra/staging
@@ -90,7 +90,7 @@ jobs:
           app-name: ${{ github.event.repository.name }}
 
   deploy-app-staging:
-    if: ${{ inputs.deploy_app && inputs.deploy_staging }}
+    if: ${{ inputs.deploy_app }}
     runs-on: ubuntu-latest
     environment:
       name: app/staging
@@ -115,10 +115,10 @@ jobs:
           cluster-name: ${{ env.ENVIRONMENT }}_${{ env.IMAGE_NAME }}_cluster
           service-name: ${{ env.ENVIRONMENT }}_${{ env.IMAGE_NAME }}-service
           task-definition-name: ${{ env.ENVIRONMENT }}_${{ env.IMAGE_NAME }}
-          image-name: ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          image-name: ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image_version }}}
 
   validate_staging:
-    if: ${{ always() && inputs.deploy_staging && contains(join(needs.*.result, ','), 'success') }}
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     needs: [deploy-app-staging, deploy-infra-staging]
     secrets: inherit
     uses: ./.github/workflows/validate.yaml

--- a/.github/workflows/ci_terraform.yaml
+++ b/.github/workflows/ci_terraform.yaml
@@ -142,4 +142,5 @@ jobs:
     with:
       deploy_app: false
       deploy_infra: true
+      deploy_production: true
     secrets: inherit


### PR DESCRIPTION
# Description

Allowing image version selection for quicker rollbacks in case something is wrong with new deployment. 
Also removed `deploy_staging` as we always deploy to staging before prod, I think possibility to not deploy to prod is enough.

Resolves #155 

## How Has This Been Tested?

GA actions change- didn't test.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
