### PR TITLE
fix: account for 500 errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -102,6 +102,14 @@ impl IntoResponse for RpcError {
                 )),
             )
                 .into_response(),
+            Self::TransportError(_) => (
+                StatusCode::BAD_GATEWAY,
+                Json(new_error_response(
+                    "transport".to_string(),
+                    "We failed to reach the provider for your request".to_string(),
+                )),
+            )
+                .into_response(),
             e => {
                 error!("Internal server error: {}", e);
                 (

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -19,7 +19,7 @@ use {
         time::{Duration, SystemTime},
     },
     tap::TapFallible,
-    tracing::info,
+    tracing::{info, log::warn},
 };
 
 pub async fn handler(
@@ -85,7 +85,14 @@ pub async fn handler(
 
     let mut response = provider
         .proxy(method, path, query_params, headers, body)
-        .await?;
+        .await
+        .tap_err(|e| {
+            warn!(
+                "Failed call to provider: {} with {}",
+                provider.provider_kind(),
+                e
+            );
+        })?;
 
     state
         .metrics


### PR DESCRIPTION
# Description

Seems like the 500's still happening in proxy are all transport errors caused by our providers mishandling our connection.
Converting them to 502's as we do with rate limiting (marking downstream provider error).

Resolves #157 

## How Has This Been Tested?

Not tested, will need to monitor the changes.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
