### PR TITLE
fix: wrong Pokt RPC endpoints used

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -53,16 +53,20 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Arbitrum
         (
             "eip155:42161".into(),
-            ("arbitrum-mainnet".into(), Weight(1.into())),
+            ("arbitrum-one".into(), Weight(1.into())),
         ),
         // Polygon
         (
             "eip155:137".into(),
-            ("polygon-mainnet".into(), Weight(5.into())),
+            ("poly-mainnet".into(), Weight(5.into())),
         ),
         (
             "eip155:80001".into(),
             ("polygon-mumbai".into(), Weight(1.into())),
+        ),
+        (
+            "eip155:1101".into(),
+            ("polygon-zkevm-mainnet".into(), Weight(5.into())),
         ),
         // Celo
         (


### PR DESCRIPTION
# Description

Wrong DNS names used for some chains

Resolves https://github.com/orgs/WalletConnect/discussions/2674

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
