### PR TITLE
feat(test): log more req/response when failing to parse response

### DIFF
--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -25,5 +25,8 @@ pub async fn send_jsonrpc_request(
 
     let (parts, body) = response.into_parts();
     let body = body::to_bytes(body).await.unwrap();
-    (parts.status, serde_json::from_slice(&body).unwrap())
+    (
+        parts.status,
+        serde_json::from_slice(&body).expect(&format!("Failed to parse {:?}", &body)),
+    )
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -12,13 +12,13 @@ pub async fn send_jsonrpc_request(
     let addr = base_addr + chain;
 
     let json = serde_json::to_string(&rpc_request).unwrap();
-    let body = Body::from(&json);
+    let req_body = Body::from(json.clone());
 
     let request = Request::builder()
         .method(Method::POST)
-        .uri(addr)
+        .uri(addr.clone())
         .header("Content-Type", "application/json")
-        .body(body)
+        .body(req_body)
         .unwrap();
 
     let response = client.request(request).await.unwrap();
@@ -29,7 +29,7 @@ pub async fn send_jsonrpc_request(
         parts.status,
         serde_json::from_slice(&body).unwrap_or_else(|_| {
             panic!(
-                "Failed to parse response '{:?}' ({} / {})",
+                "Failed to parse response '{:?}' ({} / {:?})",
                 &body, &addr, &json
             )
         }),

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -12,7 +12,7 @@ pub async fn send_jsonrpc_request(
     let addr = base_addr + chain;
 
     let json = serde_json::to_string(&rpc_request).unwrap();
-    let body = Body::from(json);
+    let body = Body::from(&json);
 
     let request = Request::builder()
         .method(Method::POST)
@@ -27,7 +27,11 @@ pub async fn send_jsonrpc_request(
     let body = body::to_bytes(body).await.unwrap();
     (
         parts.status,
-        serde_json::from_slice(&body)
-            .unwrap_or_else(|e| panic!("Failed to parse '{:?}' for chain {}: {}", &body, chain, e)),
+        serde_json::from_slice(&body).unwrap_or_else(|_| {
+            panic!(
+                "Failed to parse response '{:?}' ({} / {})",
+                &body, &addr, &json
+            )
+        }),
     )
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -28,6 +28,6 @@ pub async fn send_jsonrpc_request(
     (
         parts.status,
         serde_json::from_slice(&body)
-            .unwrap_or_else(|e| panic!("Failed to parse '{:?}': {}", &body, e)),
+            .unwrap_or_else(|e| panic!("Failed to parse '{:?}' for chain {}: {}", chain, &body, e)),
     )
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -27,6 +27,7 @@ pub async fn send_jsonrpc_request(
     let body = body::to_bytes(body).await.unwrap();
     (
         parts.status,
-        serde_json::from_slice(&body).expect(&format!("Failed to parse {:?}", &body)),
+        serde_json::from_slice(&body)
+            .unwrap_or_else(|e| panic!("Failed to parse '{:?}': {}", &body, e)),
     )
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -28,6 +28,6 @@ pub async fn send_jsonrpc_request(
     (
         parts.status,
         serde_json::from_slice(&body)
-            .unwrap_or_else(|e| panic!("Failed to parse '{:?}' for chain {}: {}", chain, &body, e)),
+            .unwrap_or_else(|e| panic!("Failed to parse '{:?}' for chain {}: {}", &body, chain, e)),
     )
 }


### PR DESCRIPTION
# Description

Currently it's unclear why Infura is failing aka doesn't contain an `id` parameter. Hopefully this will add some color.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
