### PR TITLE
refactor: minimize function params

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -27,7 +27,7 @@ pub async fn handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Query(query_params): Query<RpcQueryParams>,
     Method(method): Method,
-    path: MatchedPath,
+    _path: MatchedPath,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, RpcError> {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -83,16 +83,13 @@ pub async fn handler(
     // Start timing external provider added time
     let external_call_start = SystemTime::now();
 
-    let mut response = provider
-        .proxy(&chain_id, method, body)
-        .await
-        .tap_err(|e| {
-            warn!(
-                "Failed call to provider: {} with {}",
-                provider.provider_kind(),
-                e
-            );
-        })?;
+    let mut response = provider.proxy(&chain_id, method, body).await.tap_err(|e| {
+        warn!(
+            "Failed call to provider: {} with {}",
+            provider.provider_kind(),
+            e
+        );
+    })?;
 
     state
         .metrics

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -84,7 +84,7 @@ pub async fn handler(
     let external_call_start = SystemTime::now();
 
     let mut response = provider
-        .proxy(method, path, query_params, headers, body)
+        .proxy(&chain_id, method, body)
         .await
         .tap_err(|e| {
             warn!(

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory, RpcQueryParams},
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::BinanceConfig,
         error::{RpcError, RpcResult},

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -49,15 +49,13 @@ impl RateLimited for BinanceProvider {
 impl RpcProvider for BinanceProvider {
     async fn proxy(
         &self,
+        chain_id: &str,
         method: hyper::http::Method,
-        _path: axum::extract::MatchedPath,
-        query_params: RpcQueryParams,
-        _headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> RpcResult<Response> {
         let uri = self
             .supported_chains
-            .get(&query_params.chain_id.to_lowercase())
+            .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
         let hyper_request = hyper::http::Request::builder()

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -108,15 +108,13 @@ impl RateLimited for InfuraProvider {
 impl RpcProvider for InfuraProvider {
     async fn proxy(
         &self,
+        chain_id: &str,
         method: hyper::http::Method,
-        _path: axum::extract::MatchedPath,
-        query_params: RpcQueryParams,
-        _headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
-            .get(&query_params.chain_id.to_lowercase())
+            .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
         let uri = format!("https://{}.infura.io/v3/{}", chain, self.project_id);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -217,10 +217,8 @@ impl ProviderKind {
 pub trait RpcProvider: Provider {
     async fn proxy(
         &self,
+        chain_id: &str,
         method: hyper::http::Method,
-        xpath: axum::extract::MatchedPath,
-        query_params: RpcQueryParams,
-        headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> RpcResult<Response>;
 }

--- a/src/providers/omnia.rs
+++ b/src/providers/omnia.rs
@@ -45,15 +45,13 @@ impl RateLimited for OmniatechProvider {
 impl RpcProvider for OmniatechProvider {
     async fn proxy(
         &self,
+        chain_id: &str,
         method: hyper::http::Method,
-        _path: axum::extract::MatchedPath,
-        query_params: RpcQueryParams,
-        _headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> RpcResult<Response> {
         let chain = self
             .supported_chains
-            .get(&query_params.chain_id.to_lowercase())
+            .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
         let uri = format!("https://endpoints.omniatech.io/v1/{}/mainnet/public", chain);

--- a/src/providers/omnia.rs
+++ b/src/providers/omnia.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory, RpcQueryParams},
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::OmniatechConfig,
         error::{RpcError, RpcResult},

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -67,15 +67,13 @@ impl RateLimited for PoktProvider {
 impl RpcProvider for PoktProvider {
     async fn proxy(
         &self,
+        chain_id: &str,
         method: hyper::http::Method,
-        _path: axum::extract::MatchedPath,
-        query_params: RpcQueryParams,
-        _headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
-            .get(&query_params.chain_id.to_lowercase())
+            .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
         let uri = format!(

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory, RpcQueryParams},
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::PoktConfig,
         error::{RpcError, RpcResult},

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -42,15 +42,13 @@ impl RateLimited for PublicnodeProvider {
 impl RpcProvider for PublicnodeProvider {
     async fn proxy(
         &self,
+        chain_id: &str,
         method: hyper::http::Method,
-        _path: axum::extract::MatchedPath,
-        query_params: RpcQueryParams,
-        _headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
-            .get(&query_params.chain_id.to_lowercase())
+            .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
         let uri = format!("https://{}.publicnode.com", chain);

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory, RpcQueryParams},
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::PublicnodeConfig,
         error::{RpcError, RpcResult},

--- a/src/providers/zksync.rs
+++ b/src/providers/zksync.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory, RpcQueryParams},
+    super::{Provider, ProviderKind, RateLimited, RpcProvider, RpcProviderFactory},
     crate::{
         env::ZKSyncConfig,
         error::{RpcError, RpcResult},

--- a/src/providers/zksync.rs
+++ b/src/providers/zksync.rs
@@ -42,15 +42,13 @@ impl RateLimited for ZKSyncProvider {
 impl RpcProvider for ZKSyncProvider {
     async fn proxy(
         &self,
+        chain_id: &str,
         method: hyper::http::Method,
-        _path: axum::extract::MatchedPath,
-        query_params: RpcQueryParams,
-        _headers: hyper::http::HeaderMap,
         body: hyper::body::Bytes,
     ) -> RpcResult<Response> {
         let uri = self
             .supported_chains
-            .get(&query_params.chain_id.to_lowercase())
+            .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
         let hyper_request = hyper::http::Request::builder()


### PR DESCRIPTION
# Description

We don't need to pass path, query params, or headers to the RpcProxy. Refactoring to increase separation of concerns and futureproof re-use by ENS caching layer.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
