### PR TITLE
179 use initial weight configuration as multiplier instead of overwriting it

### DIFF
--- a/src/env/binance.rs
+++ b/src/env/binance.rs
@@ -1,4 +1,8 @@
-use {super::ProviderConfig, crate::providers::Weight, std::collections::HashMap};
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
 
 #[derive(Debug)]
 pub struct BinanceConfig {
@@ -28,14 +32,17 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Binance Smart Chain Mainnet
         (
             "eip155:56".into(),
-            ("https://bsc-dataseed.binance.org/".into(), Weight(6.into())),
+            (
+                "https://bsc-dataseed.binance.org/".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Binance Smart Chain Testnet
         (
             "eip155:97".into(),
             (
                 "https://data-seed-prebsc-1-s1.binance.org:8545".into(),
-                Weight(3.into()),
+                Weight::new(Priority::Normal).unwrap(),
             ),
         ),
     ])

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -1,4 +1,8 @@
-use {super::ProviderConfig, crate::providers::Weight, std::collections::HashMap};
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
 
 #[derive(Debug)]
 pub struct InfuraConfig {
@@ -32,52 +36,88 @@ impl ProviderConfig for InfuraConfig {
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     HashMap::from([
         // Ethereum
-        ("eip155:1".into(), ("mainnet".into(), Weight(40.into()))),
-        ("eip155:5".into(), ("goerli".into(), Weight(1.into()))),
+        (
+            "eip155:1".into(),
+            ("mainnet".into(), Weight::new(Priority::Max).unwrap()),
+        ),
+        (
+            "eip155:5".into(),
+            ("goerli".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Optimism
         (
             "eip155:10".into(),
-            ("optimism-mainnet".into(), Weight(1.into())),
+            (
+                "optimism-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:69".into(),
-            ("optimism-kovan".into(), Weight(1.into())),
+            (
+                "optimism-kovan".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:420".into(),
-            ("optimism-goerli".into(), Weight(1.into())),
+            (
+                "optimism-goerli".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Arbitrum
         (
             "eip155:42161".into(),
-            ("arbitrum-mainnet".into(), Weight(1.into())),
+            (
+                "arbitrum-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:421613".into(),
-            ("arbitrum-goerli".into(), Weight(1.into())),
+            (
+                "arbitrum-goerli".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Polygon
         (
             "eip155:137".into(),
-            ("polygon-mainnet".into(), Weight(5.into())),
+            (
+                "polygon-mainnet".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
         ),
         (
             "eip155:80001".into(),
-            ("polygon-mumbai".into(), Weight(1.into())),
+            (
+                "polygon-mumbai".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Celo
         (
             "eip155:42220".into(),
-            ("celo-mainnet".into(), Weight(1.into())),
+            (
+                "celo-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Aurora
         (
             "eip155:1313161554".into(),
-            ("aurora-mainnet".into(), Weight(1.into())),
+            (
+                "aurora-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:1313161555".into(),
-            ("aurora-testnet".into(), Weight(1.into())),
+            (
+                "aurora-testnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
     ])
 }
@@ -85,43 +125,73 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
 fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
     HashMap::from([
         // Ethereum
-        ("eip155:1".into(), ("mainnet".into(), Weight(1.into()))),
-        ("eip155:5".into(), ("goerli".into(), Weight(1.into()))),
+        (
+            "eip155:1".into(),
+            ("mainnet".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        (
+            "eip155:5".into(),
+            ("goerli".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Optimism
         (
             "eip155:10".into(),
-            ("optimism-mainnet".into(), Weight(1.into())),
+            (
+                "optimism-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:69".into(),
-            ("optimism-kovan".into(), Weight(1.into())),
+            (
+                "optimism-kovan".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:420".into(),
-            ("optimism-goerli".into(), Weight(1.into())),
+            (
+                "optimism-goerli".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Arbitrum
         (
             "eip155:42161".into(),
-            ("arbitrum-mainnet".into(), Weight(1.into())),
+            (
+                "arbitrum-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:421613".into(),
-            ("arbitrum-goerli".into(), Weight(1.into())),
+            (
+                "arbitrum-goerli".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Celo
         (
             "eip155:42220".into(),
-            ("celo-mainnet".into(), Weight(1.into())),
+            (
+                "celo-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Aurora
         (
             "eip155:1313161554".into(),
-            ("aurora-mainnet".into(), Weight(1.into())),
+            (
+                "aurora-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:1313161555".into(),
-            ("aurora-testnet".into(), Weight(1.into())),
+            (
+                "aurora-testnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
     ])
 }

--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -1,4 +1,8 @@
-use {super::ProviderConfig, crate::providers::Weight, std::collections::HashMap};
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
 
 #[derive(Debug)]
 pub struct OmniatechConfig {
@@ -26,23 +30,44 @@ impl ProviderConfig for OmniatechConfig {
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     HashMap::from([
         // Ethereum mainnet
-        ("eip155:1".into(), ("eth".into(), Weight(1.into()))),
+        (
+            "eip155:1".into(),
+            ("eth".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Binance Smart Chain mainnet
-        ("eip155:56".into(), ("bsc".into(), Weight(1.into()))),
+        (
+            "eip155:56".into(),
+            ("bsc".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Polygon
-        ("eip155:137".into(), ("matic".into(), Weight(1.into()))),
+        (
+            "eip155:137".into(),
+            ("matic".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Near
-        ("near".into(), ("near".into(), Weight(1.into()))),
+        (
+            "near".into(),
+            ("near".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Aurora
         (
             "eip155:1313161554".into(),
-            ("aurora".into(), Weight(1.into())),
+            ("aurora".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Optimism
-        ("eip155:10".into(), ("op".into(), Weight(1.into()))),
+        (
+            "eip155:10".into(),
+            ("op".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Solana
-        ("solana-mainnet".into(), ("sol".into(), Weight(1.into()))),
+        (
+            "solana-mainnet".into(),
+            ("sol".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Avalanche C chain
-        ("eip155:43114".into(), ("avax".into(), Weight(1.into()))),
+        (
+            "eip155:43114".into(),
+            ("avax".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
     ])
 }

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -1,4 +1,8 @@
-use {super::ProviderConfig, crate::providers::Weight, std::collections::HashMap};
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
 
 #[derive(Debug)]
 pub struct PoktConfig {
@@ -31,48 +35,81 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Solana Mainnet
         (
             "solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz".into(),
-            ("solana-mainnet".into(), Weight(1.into())),
+            (
+                "solana-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Avax C-Chain
         (
             "eip155:43114".into(),
-            ("avax-mainnet".into(), Weight(1.into())),
+            (
+                "avax-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Gnosis
-        ("eip155:100".into(), ("poa-xdai".into(), Weight(1.into()))),
+        (
+            "eip155:100".into(),
+            ("poa-xdai".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Binance Smart Chain
-        ("eip155:56".into(), ("bsc-mainnet".into(), Weight(5.into()))),
+        (
+            "eip155:56".into(),
+            ("bsc-mainnet".into(), Weight::new(Priority::High).unwrap()),
+        ),
         // Ethereum
         // TODO: Reenable once Pokt fixes
-        ("eip155:1".into(), ("mainnet".into(), Weight(0.into()))),
-        ("eip155:5".into(), ("goerli".into(), Weight(1.into()))),
+        (
+            "eip155:1".into(),
+            ("mainnet".into(), Weight::new(Priority::Disabled).unwrap()),
+        ),
+        (
+            "eip155:5".into(),
+            ("goerli".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Optimism
         (
             "eip155:10".into(),
-            ("optimism-mainnet".into(), Weight(1.into())),
+            (
+                "optimism-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Arbitrum
         (
             "eip155:42161".into(),
-            ("arbitrum-one".into(), Weight(1.into())),
+            (
+                "arbitrum-one".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Polygon
         (
             "eip155:137".into(),
-            ("poly-mainnet".into(), Weight(5.into())),
+            ("poly-mainnet".into(), Weight::new(Priority::High).unwrap()),
         ),
         (
             "eip155:80001".into(),
-            ("polygon-mumbai".into(), Weight(1.into())),
+            (
+                "polygon-mumbai".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         (
             "eip155:1101".into(),
-            ("polygon-zkevm-mainnet".into(), Weight(5.into())),
+            (
+                "polygon-zkevm-mainnet".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
         ),
         // Celo
         (
             "eip155:42220".into(),
-            ("celo-mainnet".into(), Weight(1.into())),
+            (
+                "celo-mainnet".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
     ])
 }

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -1,4 +1,8 @@
-use {super::ProviderConfig, crate::providers::Weight, std::collections::HashMap};
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
 
 #[derive(Debug)]
 pub struct PublicnodeConfig {
@@ -26,38 +30,56 @@ impl ProviderConfig for PublicnodeConfig {
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
     HashMap::from([
         // Ethereum mainnet
-        ("eip155:1".into(), ("ethereum".into(), Weight(10.into()))),
+        (
+            "eip155:1".into(),
+            ("ethereum".into(), Weight::new(Priority::High).unwrap()),
+        ),
         // Ethereum goerli
         (
             "eip155:5".into(),
-            ("ethereum-goerli".into(), Weight(10.into())),
+            (
+                "ethereum-goerli".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
         ),
         // Binance Smart Chain mainnet
-        ("eip155:56".into(), ("bsc".into(), Weight(10.into()))),
+        (
+            "eip155:56".into(),
+            ("bsc".into(), Weight::new(Priority::High).unwrap()),
+        ),
         // Binance Smart Chain testnet
         (
             "eip155:97".into(),
-            ("bsc-testnet".into(), Weight(10.into())),
+            ("bsc-testnet".into(), Weight::new(Priority::High).unwrap()),
         ),
         // Avalanche c chain
         (
             "eip155:43114".into(),
-            ("avalanche-c-chain".into(), Weight(1.into())),
+            (
+                "avalanche-c-chain".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
         // Avalanche fuji testnet
         (
             "eip155:43113".into(),
-            ("avalanche-fuji-c-chain".into(), Weight(10.into())),
+            (
+                "avalanche-fuji-c-chain".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
         ),
         // Polygon bor mainnet
         (
             "eip155:137".into(),
-            ("polygon-bor".into(), Weight(1.into())),
+            ("polygon-bor".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Polygon bor testnet
         (
             "eip155:80001".into(),
-            ("polygon-mumbai-bor".into(), Weight(10.into())),
+            (
+                "polygon-mumbai-bor".into(),
+                Weight::new(Priority::High).unwrap(),
+            ),
         ),
     ])
 }

--- a/src/env/zksync.rs
+++ b/src/env/zksync.rs
@@ -1,4 +1,8 @@
-use {super::ProviderConfig, crate::providers::Weight, std::collections::HashMap};
+use {
+    super::ProviderConfig,
+    crate::providers::{Priority, Weight},
+    std::collections::HashMap,
+};
 
 #[derive(Debug)]
 pub struct ZKSyncConfig {
@@ -30,13 +34,16 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:280".into(),
             (
                 "https://zksync2-testnet.zksync.dev".into(),
-                Weight(1.into()),
+                Weight::new(Priority::Normal).unwrap(),
             ),
         ),
         // zkSync Mainnet
         (
             "eip155:324".into(),
-            ("https://zksync2-mainnet.zksync.io".into(), Weight(1.into())),
+            (
+                "https://zksync2-mainnet.zksync.io".into(),
+                Weight::new(Priority::Normal).unwrap(),
+            ),
         ),
     ])
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,5 +1,5 @@
 use {
-    crate::env::ProviderConfig,
+    crate::{env::ProviderConfig, error::RpcError},
     axum::response::Response,
     axum_tungstenite::WebSocketUpgrade,
     rand::{distributions::WeightedIndex, prelude::Distribution, rngs::OsRng},
@@ -238,12 +238,80 @@ pub trait RpcWsProvider: Provider {
     ) -> RpcResult<Response>;
 }
 
+const MAX_PRIORITY: u32 = 100;
+
+pub enum Priority {
+    Max,
+    High,
+    Normal,
+    Low,
+    Disabled,
+    Custom(u32),
+}
+
+impl TryInto<PriorityValue> for Priority {
+    type Error = RpcError;
+
+    fn try_into(self) -> Result<PriorityValue, Self::Error> {
+        match self {
+            Self::Max => PriorityValue::new(MAX_PRIORITY),
+            Self::High => PriorityValue::new(MAX_PRIORITY / 4 + MAX_PRIORITY / 2),
+            Self::Normal => PriorityValue::new(MAX_PRIORITY / 2),
+            Self::Low => PriorityValue::new(MAX_PRIORITY / 4),
+            Self::Disabled => PriorityValue::new(0),
+            Self::Custom(value) => PriorityValue::new(value),
+        }
+    }
+}
+
 #[derive(Debug)]
-pub struct Weight(pub std::sync::atomic::AtomicU32);
+pub struct PriorityValue(u32);
+
+impl PriorityValue {
+    fn new(value: u32) -> RpcResult<Self> {
+        if value > MAX_PRIORITY {
+            return Err(anyhow::anyhow!(
+                "Priority value cannot be greater than {}",
+                MAX_PRIORITY
+            ))
+            .map_err(RpcError::from);
+        }
+
+        Ok(Self(value))
+    }
+
+    fn value(&self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct Weight {
+    value: std::sync::atomic::AtomicU32,
+    priority: PriorityValue,
+}
 
 impl Weight {
+    pub fn new(priority: Priority) -> RpcResult<Self> {
+        let priority_val = TryInto::<PriorityValue>::try_into(priority)?.value();
+        Ok(Self {
+            value: std::sync::atomic::AtomicU32::new(priority_val),
+            priority: PriorityValue::new(priority_val)?,
+        })
+    }
+
     pub fn value(&self) -> u32 {
-        self.0.load(std::sync::atomic::Ordering::SeqCst)
+        self.value.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    pub fn update_value(&self, value: u32) {
+        self.value.store(
+            // Calulate the new value based on the priority, with MAX_PRIORITY/2 being the "normal"
+            // value Everything above MAX_PRIORITY/2 will be prioritized, everything
+            // below will be deprioritized
+            (value * self.priority.value()) / (MAX_PRIORITY / 2),
+            std::sync::atomic::Ordering::SeqCst,
+        );
     }
 }
 

--- a/src/providers/weights.rs
+++ b/src/providers/weights.rs
@@ -112,23 +112,21 @@ pub fn update_values(weight_resolver: &WeightResolver, parsed_weights: ParsedWei
                 continue;
             };
 
-            let Some(atomic) = provider_chain_weight
+            let Some(weight) = provider_chain_weight
                 .get(&ProviderKind::from_str(&provider).unwrap()) else {
                     warn!("Weight for {} not found in weight map: {:?}", &provider, provider_chain_weight);
                     continue;
                 };
 
-            atomic
-                .0
-                .store(chain_weight, std::sync::atomic::Ordering::SeqCst);
+            weight.update_value(chain_weight);
         }
     }
 }
 
 pub fn record_values(weight_resolver: &WeightResolver, metrics: &crate::Metrics) {
     for (chain_id, provider_chain_weight) in weight_resolver {
-        for (provider_kind, atomic) in provider_chain_weight {
-            let weight = atomic.0.load(std::sync::atomic::Ordering::SeqCst);
+        for (provider_kind, weight) in provider_chain_weight {
+            let weight = weight.value();
             metrics.record_provider_weight(provider_kind, chain_id, weight.into())
         }
     }

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -84,6 +84,8 @@ resource "aws_ecs_task_definition" "app_task" {
         { "name" : "RPC_PROXY_ANALYTICS_EXPORT_BUCKET", "value" : var.analytics-data-lake_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_BUCKET", "value" : var.analytics_geoip_db_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_KEY", "value" : var.analytics_geoip_db_key },
+
+        { "name" : "PROMETHEUS_QUERY_URL", "value" : var.prometheus_endpoint },
       ],
       image : local.image,
       essential : true,


### PR DESCRIPTION
# Description

Separate weights and priorities so that we have more granular control over weights.

Resolves #179 

## How Has This Been Tested?

Tested locally using local prometheus.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
