### PR TITLE
chore: log non-POST messages to know if we can disable non-POSTs

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -27,10 +27,18 @@ pub async fn handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Query(query_params): Query<RpcQueryParams>,
     Method(method): Method,
-    _path: MatchedPath,
+    path: MatchedPath,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, RpcError> {
+    if method != hyper::Method::POST {
+        warn!(
+            "Handling non-POST method: chain_id:{}, project_id:{}, method:{method}, \
+             path:{path:?}, body:{body:?}",
+            query_params.chain_id, query_params.project_id
+        );
+    }
+
     let project = state
         .registry
         .project_data(&query_params.project_id)


### PR DESCRIPTION
# Description

Log anytime a non-POST method takes place as JSON RPC should be POST-only.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
