### PR TITLE
fix: prometheus url replaced with proxy url

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_BUCKET", "value" : var.analytics_geoip_db_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_KEY", "value" : var.analytics_geoip_db_key },
 
-        { "name" : "PROMETHEUS_QUERY_URL", "value" : var.prometheus_endpoint },
+        { "name" : "PROMETHEUS_QUERY_URL", "value" : "http://127.0.0.1:8080" },
       ],
       image : local.image,
       essential : true,


### PR DESCRIPTION
# Description

Proxy was using prometheus url instead of proxy url -> leading to 403 instead of data.

Changed to use local address with sigproxy port.

Resolves #187 

## How Has This Been Tested?

Applied to staging, terraform works. Need to redeploy app to confirm.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
