### PR TITLE
fix: connection to sigv4 proxy

### DIFF
--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -85,7 +85,8 @@ resource "aws_ecs_task_definition" "app_task" {
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_BUCKET", "value" : var.analytics_geoip_db_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_KEY", "value" : var.analytics_geoip_db_key },
 
-        { "name" : "PROMETHEUS_QUERY_URL", "value" : "http://127.0.0.1:8080" },
+        { "name" : "SIG_PROXY_URL", "value" : "http://127.0.0.1:8080/workspaces/${var.prometheus_workspace_id}" },
+        { "name" : "SIG_PROM_WORKSPACE_HEADER", "value" : "aps-workspaces.${var.region}.amazonaws.com" },
       ],
       image : local.image,
       essential : true,

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -62,6 +62,10 @@ variable "prometheus_endpoint" {
   type = string
 }
 
+variable "prometheus_workspace_id" {
+  type = string
+}
+
 variable "registry_api_endpoint" {
   type = string
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -69,7 +69,7 @@ module "ecs" {
   infura_project_id          = var.infura_project_id
   pokt_project_id            = var.pokt_project_id
   prometheus_endpoint        = aws_prometheus_workspace.prometheus.prometheus_endpoint
-  prometheus_workspace_id    = aws_prometheus_workspace.prometheus.id 
+  prometheus_workspace_id    = aws_prometheus_workspace.prometheus.id
 
   autoscaling_min_capacity = var.autoscaling_min_instances
   autoscaling_max_capacity = var.autoscaling_max_instances

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -69,6 +69,7 @@ module "ecs" {
   infura_project_id          = var.infura_project_id
   pokt_project_id            = var.pokt_project_id
   prometheus_endpoint        = aws_prometheus_workspace.prometheus.prometheus_endpoint
+  prometheus_workspace_id    = aws_prometheus_workspace.prometheus.id 
 
   autoscaling_min_capacity = var.autoscaling_min_instances
   autoscaling_max_capacity = var.autoscaling_max_instances


### PR DESCRIPTION
# Description

The rpc was at first trying to connect directly to prometheus instead of sigv4 proxy, and later was hitting proxy without proper header and workspace. This should fix it. Have no way of testing locally thought. This is still non-breaking change - if it fails, the app will default to static weights.

Resolves #188 

## How Has This Been Tested?

Terraform deployed to staging. 

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
