### PR TITLE
fix: infura provider

### DIFF
--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -56,13 +56,12 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Binance Smart Chain
         (
             "eip155:56".into(),
-            ("bsc-mainnet".into(), Weight::new(Priority::High).unwrap()),
+            ("bsc-mainnet".into(), Weight::new(Priority::Max).unwrap()),
         ),
         // Ethereum
-        // TODO: Reenable once Pokt fixes
         (
             "eip155:1".into(),
-            ("mainnet".into(), Weight::new(Priority::Disabled).unwrap()),
+            ("eth-mainnet".into(), Weight::new(Priority::Max).unwrap()),
         ),
         (
             "eip155:5".into(),


### PR DESCRIPTION
# Description

Pokt stopped working for a while for ethereum mainnet. Seems like they just deprecated old url for new one.
Also since we have new big limit for Pokt, redirecting the most troublesome traffic there with higher priority (eip155:1 & eip155:56)

Resolves #192 

## How Has This Been Tested?

Tested locally manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
