### PR TITLE
fix: priorities adjustement

### DIFF
--- a/src/env/binance.rs
+++ b/src/env/binance.rs
@@ -34,7 +34,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:56".into(),
             (
                 "https://bsc-dataseed.binance.org/".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                Weight::new(Priority::High).unwrap(),
             ),
         ),
         // Binance Smart Chain Testnet
@@ -42,7 +42,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:97".into(),
             (
                 "https://data-seed-prebsc-1-s1.binance.org:8545".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                Weight::new(Priority::High).unwrap(),
             ),
         ),
     ])

--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -32,12 +32,12 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Ethereum mainnet
         (
             "eip155:1".into(),
-            ("eth".into(), Weight::new(Priority::Normal).unwrap()),
+            ("eth".into(), Weight::new(Priority::Low).unwrap()),
         ),
         // Binance Smart Chain mainnet
         (
             "eip155:56".into(),
-            ("bsc".into(), Weight::new(Priority::Normal).unwrap()),
+            ("bsc".into(), Weight::new(Priority::Low).unwrap()),
         ),
         // Polygon
         (


### PR DESCRIPTION
# Description

Adjusting priorities for Pokt (with unblocked eth-mainnet)
Moving some traffic back to binance, as even thought they are quite limited, dynamic weights should handle that.

Resolves #194 

## How Has This Been Tested?

Untested, just priority adjustement.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
