### PR TITLE
fix: timeframe and priority for omniatech:eip155:137

### DIFF
--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -42,7 +42,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         // Polygon
         (
             "eip155:137".into(),
-            ("matic".into(), Weight::new(Priority::Normal).unwrap()),
+            ("matic".into(), Weight::new(Priority::Low).unwrap()),
         ),
         // Near
         (

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -172,7 +172,7 @@ impl ProviderRepository {
 
         match self
             .prometheus_client
-            .query("round(increase(provider_status_code_counter[12m]))")
+            .query("round(increase(provider_status_code_counter[3h]))")
             .header("host", header_value)
             .get()
             .await

--- a/src/providers/weights.rs
+++ b/src/providers/weights.rs
@@ -67,7 +67,7 @@ fn calculate_chain_weight(
     let Availability(provider_success, provider_failure) = provider_availability;
 
     // Sum failed and successful calls for provider
-    let provider_total = provider_success + provider_failure;
+    let provider_total = provider_success + provider_failure * provider_failure;
 
     let Availability(chain_success, chain_failure) = chain_availability;
 


### PR DESCRIPTION
# Description

Adjusting timeframe values for longer `memory` of failing provider.

Also decreasing priority for omniatech for `eip155:137` which seems to have increased traffic recently, while Omniatech has low traffic allowance.

Also - currently we decrease weight of chain exponentialy from the failures, but overall provider availability linearly. 
Changing to both exponential:
The initial assumption was - when a provider starts failing for one chain, it may still work properly for others. But in reality the most common issue we have is - provider reaching rate limit. We don't want to still try other chains then, when we can definitely see it's failing. So changing to more "aggresive" approach.

Resolves #201 

## How Has This Been Tested?

Dynamic weights fine tuning - untested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
