### PR TITLE
feat: more logging info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,12 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
 
     let global_middleware = ServiceBuilder::new().layer(
         TraceLayer::new_for_http()
-            .make_span_with(DefaultMakeSpan::new().include_headers(true))
-            .on_request(DefaultOnRequest::new().level(Level::DEBUG))
+            .make_span_with(
+                DefaultMakeSpan::new()
+                    .level(Level::INFO)
+                    .include_headers(true),
+            )
+            .on_request(DefaultOnRequest::new().level(Level::INFO))
             .on_response(
                 DefaultOnResponse::new()
                     .level(Level::INFO)


### PR DESCRIPTION
# Description

Log request data for more debugging possibilities.
This will help debugging both weird HTTP errors we see (524, 520) as well as missing `origin` info

Resolves #206 

## How Has This Been Tested?

Tested locally

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
