### PR TITLE
fix: CI

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,6 +6,7 @@ variable "region" {
 variable "ecr_app_version" {
   description = "The tag of the app image to deploy."
   type        = string
+  default     = "latest"
 }
 
 variable "infura_project_id" {


### PR DESCRIPTION
# Description

`ecr_app_version` variable was recently introduced in https://github.com/WalletConnect/rpc-proxy/pull/197, but I didn't account for CI which doesn't set this variable.

This PR adds a default value for this variable which matches the expected behavior before.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
