### PR TITLE
fix: metrics charts

### DIFF
--- a/terraform/monitoring/panels/identity/latency.libsonnet
+++ b/terraform/monitoring/panels/identity/latency.libsonnet
@@ -21,25 +21,25 @@ local _configuration = defaults.configuration.timeseries
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_latency{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_latency_tracker_bucket{}[$__rate_interval]))',
       refId       = "Latency",
     ))
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_cache_latency_tracker{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_cache_latency_tracker_bucket{}[$__rate_interval]))',
       refId       = "Cache latency",
     ))
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_name_latency_tracker{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_name_latency_tracker_bucket{}[$__rate_interval]))',
       refId       = "Name RPC latency",
     ))
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_avatar_latency_tracker{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_avatar_latency_tracker_bucket{}[$__rate_interval]))',
       refId       = "Avatar RPC latency",
     ))
 }

--- a/terraform/monitoring/panels/identity/usage.libsonnet
+++ b/terraform/monitoring/panels/identity/usage.libsonnet
@@ -7,7 +7,7 @@ local targets   = grafana.targets;
 {
   new(ds, vars)::
     panels.timeseries(
-      title       = 'Avatar usage',
+      title       = 'Usage',
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries.withUnit('percent'))


### PR DESCRIPTION
# Description

Fix the latency metric names (latency chart was empty).

Fix the name of the Usage chart since it is not avatar-specific.

## How Has This Been Tested?

Manually by editing prod Grafana charts. PR not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
