### PR TITLE
fix(hotfix): migrate to dedicated VPC

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.50"
+      version = "~> 5.0.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.50"
+      version = "~> 5.0.0"
     }
   }
 }
@@ -193,7 +193,7 @@ resource "aws_ecs_service" "app_service" {
   wait_for_steady_state = true
 
   network_configuration {
-    subnets          = data.aws_subnets.private_subnets.ids
+    subnets          = var.private_subnets
     assign_public_ip = false                                                                                                                     # We do public ingress through the LB
     security_groups  = [aws_security_group.tls_ingress.id, aws_security_group.vpc_app_ingress.id, aws_security_group.sigv4_proxy_vpc_ingress.id] # Setting the security group
   }

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -92,7 +92,7 @@ resource "aws_security_group" "vpc_app_ingress" {
     to_port     = var.port
     protocol    = "tcp"
     #tfsec:ignore:aws-ec2-no-public-ingress-sgr
-    cidr_blocks = ["0.0.0.0/0"] # Allowing traffic in from all sources
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {           #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
@@ -177,7 +177,7 @@ resource "aws_security_group" "vpc-endpoint-group" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [var.vpc_cidr]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {
@@ -201,16 +201,16 @@ resource "aws_vpc_endpoint" "prometheus" {
   }
 }
 
-# resource "aws_vpc_endpoint" "s3" {
-#   vpc_id            = module.vpc.vpc_id
-#   service_name      = "com.amazonaws.${var.region}.s3"
-#   vpc_endpoint_type = "Gateway"
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
 
-#   route_table_ids = module.vpc.private_route_table_ids
-# }
+  route_table_ids = var.private_route_table_ids
+}
 
 resource "aws_vpc_endpoint" "cloudwatch" {
-  vpc_id            = var.vpc_cidr
+  vpc_id            = var.vpc_id
   service_name      = "com.amazonaws.${var.region}.logs"
   vpc_endpoint_type = "Interface"
 

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -3,7 +3,7 @@
 resource "aws_alb" "network_load_balancer" {
   name               = replace("${var.app_name}-lb-${substr(uuid(), 0, 3)}", "_", "-")
   load_balancer_type = "network"
-  subnets            = var.private_subnets
+  subnets            = var.public_subnets
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -1,41 +1,9 @@
-data "aws_vpc" "vpc" {
-  filter {
-    name   = "tag:Name"
-    values = [var.vpc_name]
-  }
-}
-
-# Providing a reference to our default subnets
-data "aws_subnets" "private_subnets" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.vpc.id]
-  }
-
-  filter {
-    name   = "tag:Class"
-    values = ["private"]
-  }
-}
-
-data "aws_subnets" "public_subnets" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.vpc.id]
-  }
-
-  filter {
-    name   = "tag:Class"
-    values = ["public"]
-  }
-}
-
 # Load Balancer
 #tfsec:ignore:aws-elb-alb-not-public
 resource "aws_alb" "network_load_balancer" {
   name               = replace("${var.app_name}-lb-${substr(uuid(), 0, 3)}", "_", "-")
   load_balancer_type = "network"
-  subnets            = data.aws_subnets.public_subnets.ids
+  subnets            = var.private_subnets
 
   lifecycle {
     create_before_destroy = true
@@ -48,7 +16,7 @@ resource "aws_lb_target_group" "target_group" {
   port               = var.port
   protocol           = "TCP"
   target_type        = "ip"
-  vpc_id             = data.aws_vpc.vpc.id
+  vpc_id             = var.vpc_id
   preserve_client_ip = true
 
   # Deregister quickly to allow for faster deployments
@@ -93,7 +61,7 @@ moved {
 resource "aws_security_group" "tls_ingress" {
   name        = "${var.app_name}-tls-ingress"
   description = "Allow tls ingress from everywhere"
-  vpc_id      = data.aws_vpc.vpc.id
+  vpc_id      = var.vpc_id
 
   ingress {
     description = "allow TLS traffic from open internet to the proxy"
@@ -116,7 +84,7 @@ resource "aws_security_group" "tls_ingress" {
 resource "aws_security_group" "vpc_app_ingress" {
   name        = "${var.app_name}-vpc-ingress-to-app"
   description = "Allow app port ingress from vpc"
-  vpc_id      = data.aws_vpc.vpc.id
+  vpc_id      = var.vpc_id
 
   ingress {
     description = "allow traffic from open internet to the proxy (needed since lb has client ip forwarding)"
@@ -139,7 +107,7 @@ resource "aws_security_group" "vpc_app_ingress" {
 resource "aws_security_group" "sigv4_proxy_vpc_ingress" {
   name        = "${var.app_name}-vpc-ingress-to-sigv4"
   description = "Allow ingress from inside of vpc to sigv4"
-  vpc_id      = data.aws_vpc.vpc.id
+  vpc_id      = var.vpc_id
 
   ingress {
     description = "allow traffic from inside of cidr block to sigv4 proxy"
@@ -147,7 +115,7 @@ resource "aws_security_group" "sigv4_proxy_vpc_ingress" {
     to_port     = 8080
     protocol    = "tcp"
     #tfsec:ignore:aws-ec2-no-public-ingress-sgr
-    cidr_blocks = [data.aws_vpc.vpc.cidr_block] # Allowing traffic in from the cidr block 
+    cidr_blocks = [var.vpc_cidr] # Allowing traffic in from the cidr block 
   }
 
   egress {           #tfsec:ignore:aws-ec2-add-description-to-security-group-rule
@@ -195,13 +163,13 @@ resource "aws_lb_listener_certificate" "backup_cert" {
 resource "aws_security_group" "vpc-endpoint-group" {
   name        = "${var.environment}.${var.region}.${var.app_name}-vpc-endpoint"
   description = "Allow tls ingress from VPC"
-  vpc_id      = data.aws_vpc.vpc.id
+  vpc_id      = var.vpc_id
   ingress {
     description = "allow TLS traffic from vpc to the proxy"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = [data.aws_vpc.vpc.cidr_block]
+    cidr_blocks = [var.vpc_cidr]
   }
 
   egress {
@@ -209,7 +177,7 @@ resource "aws_security_group" "vpc-endpoint-group" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [data.aws_vpc.vpc.cidr_block]
+    cidr_blocks = [var.vpc_cidr]
   }
 
   tags = {
@@ -218,11 +186,83 @@ resource "aws_security_group" "vpc-endpoint-group" {
 }
 
 resource "aws_vpc_endpoint" "prometheus" {
-  vpc_id            = data.aws_vpc.vpc.id
+  vpc_id            = var.vpc_id
   service_name      = "com.amazonaws.${var.region}.aps-workspaces"
   vpc_endpoint_type = "Interface"
 
-  subnet_ids = data.aws_subnets.private_subnets.ids
+  subnet_ids = var.private_subnets
+
+  security_group_ids = [
+    aws_security_group.vpc-endpoint-group.id,
+  ]
+
+  tags = {
+    Application = var.app_name
+  }
+}
+
+# resource "aws_vpc_endpoint" "s3" {
+#   vpc_id            = module.vpc.vpc_id
+#   service_name      = "com.amazonaws.${var.region}.s3"
+#   vpc_endpoint_type = "Gateway"
+
+#   route_table_ids = module.vpc.private_route_table_ids
+# }
+
+resource "aws_vpc_endpoint" "cloudwatch" {
+  vpc_id            = var.vpc_cidr
+  service_name      = "com.amazonaws.${var.region}.logs"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = var.private_subnets
+
+  security_group_ids = [
+    aws_security_group.vpc-endpoint-group.id,
+  ]
+
+  tags = {
+    Application = var.app_name
+  }
+}
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${var.region}.ssm"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = var.private_subnets
+
+  security_group_ids = [
+    aws_security_group.vpc-endpoint-group.id,
+  ]
+
+  tags = {
+    Application = var.app_name
+  }
+}
+
+resource "aws_vpc_endpoint" "dkr" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${var.region}.ecr.dkr"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = var.private_subnets
+
+  security_group_ids = [
+    aws_security_group.vpc-endpoint-group.id,
+  ]
+
+  tags = {
+    Application = var.app_name
+  }
+}
+
+resource "aws_vpc_endpoint" "ecrapi" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${var.region}.ecr.api"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = var.private_subnets
 
   security_group_ids = [
     aws_security_group.vpc-endpoint-group.id,

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -120,6 +120,10 @@ variable "autoscaling_min_capacity" {
   type = number
 }
 
+variable "private_route_table_ids" {
+  type = set(string)
+}
+
 variable "public_subnets" {
   type = set(string)
 }

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -19,10 +19,6 @@ variable "region" {
   type = string
 }
 
-variable "vpc_name" {
-  type = string
-}
-
 variable "port" {
   type = number
 }
@@ -122,4 +118,20 @@ variable "autoscaling_max_capacity" {
 
 variable "autoscaling_min_capacity" {
   type = number
+}
+
+variable "public_subnets" {
+  type = set(string)
+}
+
+variable "private_subnets" {
+  type = set(string)
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,6 +87,7 @@ module "ecs" {
   public_subnets             = module.vpc.public_subnets
   vpc_cidr                   = module.vpc.vpc_cidr_block
   vpc_id                     = module.vpc.vpc_id
+  private_route_table_ids    = module.vpc.private_route_table_ids
   port                       = 3000
   private_port               = 4000
   acm_certificate_arn        = module.dns.certificate_arn

--- a/terraform/monitoring/terraform.tf
+++ b/terraform/monitoring/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.50"
+      version = "~> 5.0.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/terraform/private_zone/main.tf
+++ b/terraform/private_zone/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.50"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/terraform/redis/variables.tf
+++ b/terraform/redis/variables.tf
@@ -20,10 +20,6 @@ variable "allowed_egress_cidr_blocks" {
   default = null
 }
 
-variable "vpc_name" {
-  type = string
-}
-
 variable "zone_id" {
   type    = string
   default = null
@@ -32,4 +28,16 @@ variable "zone_id" {
 variable "zone_name" {
   type    = string
   default = null
+}
+
+variable "private_subnets" {
+  type = set(string)
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,6 +17,11 @@ variable "pokt_project_id" {
   type = string
 }
 
+variable "azs" {
+  type    = list(string)
+  default = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
+}
+
 variable "grafana_endpoint" {
   type = string
 }


### PR DESCRIPTION
# Description

See https://www.notion.so/walletconnect/Postmortem-RPC-Down-June-30-f4a6ee010b2544fe82ece0fe38ba3f10

RPC proxy now runs in its own VPC.
Also adding some more VPC endpoints.

## How Has This Been Tested?

Applied to staging

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
