### PR TITLE
fix: Redis DNS not discoverable

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -127,8 +127,6 @@ module "redis" {
   vpc_cidr        = module.vpc.vpc_cidr_block
   vpc_id          = module.vpc.vpc_id
   zone_id         = local.zone_id
-
-  depends_on = [module.private_hosted_zone]
 }
 
 module "monitoring" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,6 @@ locals {
   app_name                = "rpc-proxy"
   hosted_zone_name        = "rpc.walletconnect.com"
   backup_hosted_zone_name = "rpc.walletconnect.org"
-  private_zone_name       = "rpc.repl.internal"
   fqdn                    = terraform.workspace == "prod" ? local.hosted_zone_name : "${terraform.workspace}.${local.hosted_zone_name}"
   backup_fqdn             = terraform.workspace == "prod" ? local.backup_hosted_zone_name : "${terraform.workspace}.${local.backup_hosted_zone_name}"
 
@@ -118,18 +117,6 @@ module "ecs" {
   analytics_geoip_db_key          = var.analytics_geoip_db_key
 }
 
-module "private_hosted_zone" {
-  count  = terraform.workspace == "prod" ? 1 : 0
-  source = "./private_zone"
-
-  name     = local.private_zone_name
-  vpc_name = "ops-${terraform.workspace}-vpc"
-}
-
-locals {
-  zone_id = terraform.workspace == "prod" ? module.private_hosted_zone[0].zone_id : null
-}
-
 module "redis" {
   source = "./redis"
 
@@ -140,7 +127,6 @@ module "redis" {
   vpc_cidr        = module.vpc.vpc_cidr_block
   vpc_id          = module.vpc.vpc_id
   zone_id         = local.zone_id
-  zone_name       = local.private_zone_name
 
   depends_on = [module.private_hosted_zone]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -126,7 +126,6 @@ module "redis" {
   private_subnets = module.vpc.private_subnets
   vpc_cidr        = module.vpc.vpc_cidr_block
   vpc_id          = module.vpc.vpc_id
-  zone_id         = local.zone_id
 }
 
 module "monitoring" {

--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -55,16 +55,6 @@ resource "aws_security_group" "service_security_group" {
   }
 }
 
-# DNS
-resource "aws_route53_record" "dns" {
-  count   = terraform.workspace == "prod" ? 1 : 0
-  zone_id = var.zone_id
-  name    = "${replace("${var.redis_name}-redis", "_", "-")}.${local.zone_name}"
-  type    = "CNAME"
-  ttl     = "30"
-  records = [for cache_node in aws_elasticache_cluster.cache.cache_nodes : cache_node.address]
-}
-
 locals {
   cache_endpoint = "${aws_elasticache_cluster.cache.cache_nodes[0].address}:${aws_elasticache_cluster.cache.cache_nodes[0].port}"
 }

--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -9,10 +9,6 @@ terraform {
   }
 }
 
-locals {
-  zone_name = var.zone_name == null ? "local" : var.zone_name
-}
-
 resource "aws_elasticache_cluster" "cache" {
   cluster_id           = replace("${var.app_name}-${var.redis_name}", "_", "-")
   engine               = "redis"

--- a/terraform/redis/outputs.tf
+++ b/terraform/redis/outputs.tf
@@ -1,5 +1,5 @@
 output "endpoint" {
-  value = var.zone_id == null ? local.cache_endpoint : aws_route53_record.dns[0].fqdn
+  value = local.cache_endpoint
 }
 
 output "cluster_id" {

--- a/terraform/redis/variables.tf
+++ b/terraform/redis/variables.tf
@@ -20,11 +20,6 @@ variable "allowed_egress_cidr_blocks" {
   default = null
 }
 
-variable "zone_name" {
-  type    = string
-  default = null
-}
-
 variable "private_subnets" {
   type = set(string)
 }

--- a/terraform/redis/variables.tf
+++ b/terraform/redis/variables.tf
@@ -20,11 +20,6 @@ variable "allowed_egress_cidr_blocks" {
   default = null
 }
 
-variable "zone_id" {
-  type    = string
-  default = null
-}
-
 variable "zone_name" {
   type    = string
   default = null


### PR DESCRIPTION
# Description

The DNS hosted zone was no longer in the default VPC. Hence it would have to be added to the VPC explicitly. However, this was a bad solution in the first place. Hence, removing.

## How Has This Been Tested?

Applied

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
