### PR TITLE
217 add pernament weight graphs to grafana

### DIFF
--- a/terraform/monitoring/dashboard.jsonnet
+++ b/terraform/monitoring/dashboard.jsonnet
@@ -65,6 +65,14 @@ dashboard.new(
     panels.usage.provider(ds, vars, 'Binance')     { gridPos: pos._3 },
     panels.usage.provider(ds, vars, 'Pokt')        { gridPos: pos._3 },
 
+  row.new('Provider Weights'),
+    panels.weights.provider(ds, vars, 'Infura')    { gridPos: pos._3 },
+    panels.weights.provider(ds, vars, 'zkSync')    { gridPos: pos._3 },
+    panels.weights.provider(ds, vars, 'Publicnode'){ gridPos: pos._3 },
+    panels.weights.provider(ds, vars, 'Omniatech') { gridPos: pos._3 },
+    panels.weights.provider(ds, vars, 'Binance')   { gridPos: pos._3 },
+    panels.weights.provider(ds, vars, 'Pokt')      { gridPos: pos._3 },
+
   row.new('Status Codes'),
     panels.status.provider(ds, vars, 'Infura')      { gridPos: pos._3 },
     panels.status.provider(ds, vars, 'zkSync')      { gridPos: pos._3 },

--- a/terraform/monitoring/panels/panels.libsonnet
+++ b/terraform/monitoring/panels/panels.libsonnet
@@ -5,6 +5,10 @@
     memory:               (import 'ecs/memory.libsonnet'                  ).new,
   },
 
+  weights: {
+    provider:             (import 'weights/provider.libsonnet'            ).new,
+  },
+
   usage: {
     provider:             (import 'usage/provider.libsonnet'              ).new,
   },

--- a/terraform/monitoring/panels/weights/provider.libsonnet
+++ b/terraform/monitoring/panels/weights/provider.libsonnet
@@ -1,0 +1,20 @@
+local grafana   = import '../../grafonnet-lib/grafana.libsonnet';
+local defaults  = import '../../grafonnet-lib/defaults.libsonnet';
+
+local panels    = grafana.panels;
+local targets   = grafana.targets;
+
+{
+  new(ds, vars, provider)::
+    panels.timeseries(
+      title       = provider,
+      datasource  = ds.prometheus,
+    )
+    .configure(defaults.configuration.timeseries)
+
+    .addTarget(targets.prometheus(
+      datasource  = ds.prometheus,
+      expr          = 'sum by (chain_id) (increase(provider_weights_sum{provider="%s"}[5m])) / sum by (chain_id) (increase(provider_weights_count{provider="%s"}[5m]))' % [provider, provider],
+      legendFormat  = '__auto',
+    ))
+}


### PR DESCRIPTION
# Description

Adding weight graphs pernamently.

Resolves #217 

## How Has This Been Tested?

Deployed to staging.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
