### PR TITLE
feat: no more 404 for name not found

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        error::{new_error_response, RpcError},
+        error::RpcError,
         extractors::method::Method,
         handlers::RpcQueryParams,
         json_rpc::{JsonRpcError, JsonRpcResponse},
@@ -32,7 +32,7 @@ use {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityResponse {
-    name: String,
+    name: Option<String>,
     avatar: Option<String>,
 }
 
@@ -57,25 +57,14 @@ pub async fn handler(
     state.metrics.add_identity_lookup_latency(start, &source);
     state.metrics.add_identity_lookup_success(&source);
 
-    if let Some(IdentityResponse { avatar, .. }) = &res {
+    if res.name.is_some() {
         state.metrics.add_identity_lookup_name_present();
-        if avatar.is_some() {
-            state.metrics.add_identity_lookup_avatar_present();
-        }
+    }
+    if res.avatar.is_some() {
+        state.metrics.add_identity_lookup_avatar_present();
     }
 
-    Ok(if let Some(res) = res {
-        Json(res).into_response()
-    } else {
-        (
-            StatusCode::NOT_FOUND,
-            Json(new_error_response(
-                "address".to_string(),
-                "Could not find the address".to_owned(),
-            )),
-        )
-            .into_response()
-    })
+    Ok(Json(res).into_response())
 }
 
 pub enum IdentityLookupSource {
@@ -99,7 +88,7 @@ async fn lookup_identity(
     query: Query<RpcQueryParams>,
     path: MatchedPath,
     headers: HeaderMap,
-) -> Result<(IdentityLookupSource, Option<IdentityResponse>), RpcError> {
+) -> Result<(IdentityLookupSource, IdentityResponse), RpcError> {
     let cache_key = format!("{}", address);
     if let Some(cache) = &state.identity_cache {
         debug!("Checking cache for identity");
@@ -142,7 +131,7 @@ async fn lookup_identity_rpc(
     query: Query<RpcQueryParams>,
     path: MatchedPath,
     headers: HeaderMap,
-) -> Result<Option<IdentityResponse>, RpcError> {
+) -> Result<IdentityResponse, RpcError> {
     let provider = Provider::new(SelfProvider {
         state: state.clone(),
         connect_info,
@@ -171,7 +160,12 @@ async fn lookup_identity_rpc(
     state.metrics.add_identity_lookup_name_success();
     let name = match name {
         Some(name) => name,
-        None => return Ok(None),
+        None => {
+            return Ok(IdentityResponse {
+                name: None,
+                avatar: None,
+            });
+        }
     };
 
     debug!("Beginning avatar lookup");
@@ -198,7 +192,10 @@ async fn lookup_identity_rpc(
         .add_identity_lookup_avatar_latency(avatar_lookup_start);
     state.metrics.add_identity_lookup_avatar_success();
 
-    Ok(Some(IdentityResponse { name, avatar }))
+    Ok(IdentityResponse {
+        name: Some(name),
+        avatar,
+    })
 }
 
 struct SelfProvider {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
         .project_data_redis_addr()
         .map(|addr| redis::Redis::new(&addr, config.storage.redis_max_connections))
         .transpose()?
-        .map(|r| Arc::new(r) as Arc<dyn KeyValueStorage<Option<IdentityResponse>> + 'static>);
+        .map(|r| Arc::new(r) as Arc<dyn KeyValueStorage<IdentityResponse> + 'static>);
     let providers = init_providers();
 
     let external_ip = config

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,7 +19,7 @@ pub struct AppState {
     pub exporter: PrometheusExporter,
     pub metrics: Arc<Metrics>,
     pub registry: Registry,
-    pub identity_cache: Option<Arc<dyn KeyValueStorage<Option<IdentityResponse>>>>,
+    pub identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     pub analytics: RPCAnalytics,
     pub compile_info: CompileInfo,
 }
@@ -30,7 +30,7 @@ pub fn new_state(
     exporter: PrometheusExporter,
     metrics: Arc<Metrics>,
     registry: Registry,
-    identity_cache: Option<Arc<dyn KeyValueStorage<Option<IdentityResponse>>>>,
+    identity_cache: Option<Arc<dyn KeyValueStorage<IdentityResponse>>>,
     analytics: RPCAnalytics,
 ) -> AppState {
     AppState {


### PR DESCRIPTION
# Description

No longer return a 404 when the name cannot be found. Instead, the `name` field in the response is now optional and you'll get back `{ name: null, avatar: null }`.

Consumers of this API should assume that a `null` name will also result in a `null` avatar, but this isn't enforced by the types. This was simpler than `{ name: string, avatar: string | null } | null`

Resolves #215 

## How Has This Been Tested?

Locally with Web3Modal

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
