### PR TITLE
feat: remove request/response logger

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,12 +137,6 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
                     .level(Level::INFO)
                     .include_headers(true),
             )
-            .on_request(DefaultOnRequest::new().level(Level::INFO))
-            .on_response(
-                DefaultOnResponse::new()
-                    .level(Level::INFO)
-                    .include_headers(true),
-            ),
     );
 
     let proxy_state = state_arc.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use {
     tower::ServiceBuilder,
     tower_http::{
         cors::{Any, CorsLayer},
-        trace::{DefaultMakeSpa, TraceLayer},
+        trace::{DefaultMakeSpan, TraceLayer},
     },
     tracing::{info, log::warn, Level, Span},
 };
@@ -131,12 +131,11 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     ]);
 
     let global_middleware = ServiceBuilder::new().layer(
-        TraceLayer::new_for_http()
-            .make_span_with(
-                DefaultMakeSpan::new()
-                    .level(Level::INFO)
-                    .include_headers(true),
-            )
+        TraceLayer::new_for_http().make_span_with(
+            DefaultMakeSpan::new()
+                .level(Level::INFO)
+                .include_headers(true),
+        ),
     );
 
     let proxy_state = state_arc.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use {
     tower::ServiceBuilder,
     tower_http::{
         cors::{Any, CorsLayer},
-        trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
+        trace::{DefaultMakeSpa, TraceLayer},
     },
     tracing::{info, log::warn, Level, Span},
 };


### PR DESCRIPTION
# Description

We spend $600/month on RPC Logging. These request/response logs we've never actioned so removing. However, better would be a config to only log them for non-HTTP2XX but I don't know how.

# Testing

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
