### PR TITLE
227 grafana broken after changing the opentelemetry version

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -179,7 +179,7 @@ impl ProviderRepository {
 
         match self
             .prometheus_client
-            .query("round(increase(provider_status_code_counter[3h]))")
+            .query("round(increase(provider_status_code_counter_total[3h]))")
             .header("host", header_value)
             .get()
             .await

--- a/terraform/monitoring/panels/ecs/availability.libsonnet
+++ b/terraform/monitoring/panels/ecs/availability.libsonnet
@@ -6,30 +6,6 @@ local targets        = grafana.targets;
 local alert          = grafana.alert;
 local alertCondition = grafana.alertCondition;
 
-local no_data_alert(vars) = alert.new(
-  namespace   = 'RPC',
-  name        = "RPC %s - No Data alert" % vars.environment,
-  message     = "RPC %s - No Data alert" % vars.environment,
-  period      = '5m',
-  frequency   = '1m',
-  noDataState = 'alerting',
-  notifications = vars.notifications,
-  alertRuleTags = {
-    'og_priority': 'P3',
-  },
-  
-  conditions  = [
-    alertCondition.new(
-      evaluatorParams = [ 1 ],
-      evaluatorType   = 'lt',
-      operatorType    = 'or',
-      queryRefId      = 'total',
-      queryTimeStart  = '5m',
-      reducerType     = 'sum',
-    ),
-  ]
-);
-
 
 {
   new(ds, vars)::
@@ -45,25 +21,24 @@ local no_data_alert(vars) = alert.new(
           axisSoftMax = 100,
         )
     )
-    .setAlert(no_data_alert(vars))
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(http_call_counter{aws_ecs_task_family=\"%s_rpc-proxy\",code=~\"5.+\"}[5m])) or vector(0)' % vars.environment,
+      expr        = 'sum(rate(http_call_counter_total{aws_ecs_task_family=\"%s_rpc-proxy\",code=~\"5.+\"}[5m])) or vector(0)' % vars.environment,
       refId       = "errors",
       exemplar    = false,
       hide        = true,
     ))
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(http_call_counter{aws_ecs_task_family=\"%s_rpc-proxy\",code=\"429\"}[5m])) or vector(0)' % vars.environment,
+      expr        = 'sum(rate(http_call_counter_total{aws_ecs_task_family=\"%s_rpc-proxy\",code=\"429\"}[5m])) or vector(0)' % vars.environment,
       refId       = 'rate_limits',
       exemplar    = false,
       hide        = true,
     ))
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(http_call_counter{aws_ecs_task_family=\"%s_rpc-proxy\"}[5m]))' % vars.environment,
+      expr        = 'sum(rate(http_call_counter_total{aws_ecs_task_family=\"%s_rpc-proxy\"}[5m]))' % vars.environment,
       refId       = 'total',
       exemplar    = false,
       hide        = true,

--- a/terraform/monitoring/panels/ecs/availability.libsonnet
+++ b/terraform/monitoring/panels/ecs/availability.libsonnet
@@ -40,11 +40,12 @@ local alertCondition = grafana.alertCondition;
       datasource  = ds.prometheus,
       expr        = 'sum(rate(http_call_counter_total{aws_ecs_task_family=\"%s_rpc-proxy\"}[5m]))' % vars.environment,
       refId       = 'total',
-      exemplar    = false,
+      exemplar    = true,
       hide        = true,
     ))
     .addTarget(targets.math(
       expr        = '(1 - (($errors + $rate_limits) / $total)) * 100',
       refId       = "Availability",
     ))
+   
 }

--- a/terraform/monitoring/panels/identity/availability.libsonnet
+++ b/terraform/monitoring/panels/identity/availability.libsonnet
@@ -21,14 +21,14 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_counter_total{}[$__rate_interval]))',
       refId       = "lookup",
       hide        = true,
     ))
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_success_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_success_counter_total{}[$__rate_interval]))',
       refId       = "lookup_success",
       hide        = true,
     ))
@@ -39,13 +39,13 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_name_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_name_counter_total{}[$__rate_interval]))',
       refId       = "lookup_name",
       hide        = true,
     ))
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_name_success_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_name_success_counter_total{}[$__rate_interval]))',
       refId       = "lookup_name_success",
       hide        = true,
     ))
@@ -56,13 +56,13 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_avatar_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_avatar_counter_total{}[$__rate_interval]))',
       refId       = "lookup_avatar",
       hide        = true,
     ))
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_avatar_success_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_avatar_success_counter_total{}[$__rate_interval]))',
       refId       = "lookup_avatar_success",
       hide        = true,
     ))

--- a/terraform/monitoring/panels/identity/cache.libsonnet
+++ b/terraform/monitoring/panels/identity/cache.libsonnet
@@ -21,7 +21,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_success_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_success_counter_total{}[$__rate_interval]))',
       refId       = "lookups",
       exemplar    = false,
       hide        = true,
@@ -29,7 +29,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_success_counter{source="cache"}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_success_counter_total{source="cache"}[$__rate_interval]))',
       refId       = "cache_hits",
       exemplar    = false,
       hide        = true,

--- a/terraform/monitoring/panels/identity/requests.libsonnet
+++ b/terraform/monitoring/panels/identity/requests.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_counter_total{}[$__rate_interval]))',
       refId       = "Requests",
     ))
 }

--- a/terraform/monitoring/panels/identity/usage.libsonnet
+++ b/terraform/monitoring/panels/identity/usage.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_success_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_success_counter_total{}[$__rate_interval]))',
       refId       = "lookups",
       exemplar    = false,
       hide        = true,
@@ -22,7 +22,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_name_present_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_name_present_counter_total{}[$__rate_interval]))',
       refId       = "name_present",
       exemplar    = false,
       hide        = true,
@@ -30,7 +30,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_lookup_avatar_present_counter{}[$__rate_interval]))',
+      expr        = 'sum(rate(identity_lookup_avatar_present_counter_total{}[$__rate_interval]))',
       refId       = "avatar_present",
       exemplar    = false,
       hide        = true,

--- a/terraform/monitoring/panels/proxy/calls.libsonnet
+++ b/terraform/monitoring/panels/proxy/calls.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by(chain_id) (increase(rpc_call_counter{aws_ecs_task_family="%s_rpc-proxy"}[5m]))' % vars.environment,
+      expr          = 'sum by(chain_id) (increase(rpc_call_counter_total{aws_ecs_task_family="%s_rpc-proxy"}[5m]))' % vars.environment,
       exemplar      = false,
       legendFormat  = '__auto',
     ))

--- a/terraform/monitoring/panels/proxy/errors_non_provider.libsonnet
+++ b/terraform/monitoring/panels/proxy/errors_non_provider.libsonnet
@@ -41,7 +41,7 @@ local error_alert(vars) = alert.new(
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'round(sum(increase(http_call_counter{code=~"50[0-1]|503|50[5-9]|5[1-9][0-9]"}[5m])))',
+      expr        = 'round(sum(increase(http_call_counter_total{code=~"50[0-1]|503|50[5-9]|5[1-9][0-9]"}[5m])))',
       refId       = "non_provider_errors",
       exemplar    = true,
     )) 

--- a/terraform/monitoring/panels/proxy/errors_provider.libsonnet
+++ b/terraform/monitoring/panels/proxy/errors_provider.libsonnet
@@ -41,7 +41,7 @@ local error_alert(vars) = alert.new(
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr        = 'round(sum(increase(http_call_counter{code=\"502\"}[5m])))',
+      expr        = 'round(sum(increase(http_call_counter_total{code=\"502\"}[5m])))',
       refId       = "bad_gateway",
     ))
 }

--- a/terraform/monitoring/panels/proxy/http_codes.libsonnet
+++ b/terraform/monitoring/panels/proxy/http_codes.libsonnet
@@ -21,7 +21,7 @@ local _configuration = defaults.configuration.timeseries
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by (code)(rate(http_call_counter{aws_ecs_task_family=\"%s_rpc-proxy\"}[5m]))' % vars.environment,
+      expr          = 'sum by (code)(rate(http_call_counter_total{aws_ecs_task_family=\"%s_rpc-proxy\"}[5m]))' % vars.environment,
       exemplar      = false,
       legendFormat  = '__auto',
     ))

--- a/terraform/monitoring/panels/proxy/rejected_projects.libsonnet
+++ b/terraform/monitoring/panels/proxy/rejected_projects.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum (increase(rejected_project_counter[5m]))',
+      expr          = 'sum (increase(rejected_project_counter_total[5m]))',
       legendFormat  = '__auto',
     ))
 }

--- a/terraform/monitoring/panels/status/provider.libsonnet
+++ b/terraform/monitoring/panels/status/provider.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by(status_code) (increase(provider_status_code_counter{provider="%s"}[$__rate_interval]))' % provider,
+      expr          = 'sum by(status_code) (increase(provider_status_code_counter_total{provider="%s"}[$__rate_interval]))' % provider,
       legendFormat  = '__auto',
     ))
 }

--- a/terraform/monitoring/panels/usage/provider.libsonnet
+++ b/terraform/monitoring/panels/usage/provider.libsonnet
@@ -14,7 +14,7 @@ local targets   = grafana.targets;
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,
-      expr          = 'sum by(chain_id) (increase(provider_status_code_counter{provider="%s"}[5m]))' % provider,
+      expr          = 'sum by(chain_id) (increase(provider_status_code_counter_total{provider="%s"}[5m]))' % provider,
       legendFormat  = '__auto',
     ))
 }


### PR DESCRIPTION
# Description

Fixing grafana boards

Temporarely disabling no-data alarm which is breaking, tracked in different issue:
https://github.com/WalletConnect/rpc-proxy/issues/228

Resolves #227 

## How Has This Been Tested?

Manually deployed and verified

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
