### PR TITLE
233 better availability alarms

### DIFF
--- a/terraform/monitoring/panels/ecs/availability.libsonnet
+++ b/terraform/monitoring/panels/ecs/availability.libsonnet
@@ -20,7 +20,7 @@ local error_alert(vars) = alert.new(
   
   conditions  = [
     alertCondition.new(
-      evaluatorParams = [ 98 ],
+      evaluatorParams = [ 95 ],
       evaluatorType   = 'lt',
       operatorType    = 'or',
       queryRefId      = 'availability',

--- a/terraform/monitoring/panels/proxy/errors_non_provider.libsonnet
+++ b/terraform/monitoring/panels/proxy/errors_non_provider.libsonnet
@@ -6,30 +6,6 @@ local targets         = grafana.targets;
 local alert           = grafana.alert;
 local alertCondition  = grafana.alertCondition;
 
-local error_alert(vars) = alert.new(
-  namespace   = 'RPC',
-  name        = "RPC %s - Non-Provider Error alert" % vars.environment,
-  message     = "RPC %s - Non-Provider Error alert" % vars.environment,
-  period      = '5m',
-  frequency   = '1m',
-  noDataState = 'no_data',
-  notifications = vars.notifications,
-  alertRuleTags = {
-    'og_priority': 'P3',
-  },
-  
-  conditions  = [
-    alertCondition.new(
-      evaluatorParams = [ 15 ],
-      evaluatorType   = 'gt',
-      operatorType    = 'or',
-      queryRefId      = 'non_provider_errors',
-      queryTimeStart  = '5m',
-      reducerType     = 'sum',
-    ),
-  ]
-);
-
 {
   new(ds, vars)::
     panels.timeseries(
@@ -37,7 +13,6 @@ local error_alert(vars) = alert.new(
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)
-    .setAlert(error_alert(vars))
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,

--- a/terraform/monitoring/panels/proxy/errors_provider.libsonnet
+++ b/terraform/monitoring/panels/proxy/errors_provider.libsonnet
@@ -6,30 +6,6 @@ local targets         = grafana.targets;
 local alert           = grafana.alert;
 local alertCondition  = grafana.alertCondition;
 
-local error_alert(vars) = alert.new(
-  namespace   = 'RPC',
-  name        = "RPC %s - Provider Error alert" % vars.environment,
-  message     = "RPC %s - Provider Error alert" % vars.environment,
-  period      = '5m',
-  frequency   = '1m',
-  noDataState = 'no_data',
-  notifications = vars.notifications,
-  alertRuleTags = {
-    'og_priority': 'P3',
-  },
-  
-  conditions  = [
-    alertCondition.new(
-      evaluatorParams = [ 5000 ],
-      evaluatorType   = 'gt',
-      operatorType    = 'or',
-      queryRefId      = 'bad_gateway',
-      queryTimeStart  = '5m',
-      reducerType     = 'sum',
-    ),
-  ]
-);
-
 {
   new(ds, vars)::
     panels.timeseries(
@@ -37,7 +13,6 @@ local error_alert(vars) = alert.new(
       datasource  = ds.prometheus,
     )
     .configure(defaults.configuration.timeseries)
-    .setAlert(error_alert(vars))
 
     .addTarget(targets.prometheus(
       datasource  = ds.prometheus,


### PR DESCRIPTION
# Description

Removing the provider/non-provider alarms. Configuring `availability` alarm instead.
I'm not sure what's the issue, but grafana didn't want to accept alarm on math expression, but for the same expression, but in query it seems to work.

Resolves #233 

## How Has This Been Tested?

Deployed by hand and verified.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
