### PR TITLE
feat: add metrics for number of ws connections

### DIFF
--- a/src/handlers/ws_proxy.rs
+++ b/src/handlers/ws_proxy.rs
@@ -31,5 +31,7 @@ pub async fn handler(
         .get_ws_provider_for_chain_id(&chain_id)
         .ok_or(RpcError::UnsupportedChain(chain_id.clone()))?;
 
+    state.metrics.add_websocket_connection(chain_id);
+
     provider.proxy(ws, query_params).await
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -32,6 +32,7 @@ pub struct Metrics {
     pub identity_lookup_avatar_latency_tracker: Histogram<f64>,
     pub identity_lookup_avatar_present_counter: Counter<u64>,
     pub identity_lookup_name_present_counter: Counter<u64>,
+    pub websocket_connection_counter: Counter<u64>,
 }
 
 impl Metrics {
@@ -146,6 +147,11 @@ impl Metrics {
             .with_description("The number of identity lookups that returned an avatar")
             .init();
 
+        let websocket_connection_counter = meter
+            .u64_counter("websocket_connection_counter")
+            .with_description("The number of websocket connections")
+            .init();
+
         Metrics {
             rpc_call_counter,
             http_call_counter,
@@ -169,6 +175,7 @@ impl Metrics {
             identity_lookup_avatar_latency_tracker,
             identity_lookup_name_present_counter,
             identity_lookup_avatar_present_counter,
+            websocket_connection_counter,
         }
     }
 }
@@ -337,5 +344,12 @@ impl Metrics {
     pub fn add_identity_lookup_avatar_present(&self) {
         self.identity_lookup_avatar_present_counter
             .add(&opentelemetry::Context::new(), 1, &[]);
+    }
+
+    pub fn add_websocket_connection(&self, chain_id: String) {
+        self.websocket_connection_counter
+            .add(&opentelemetry::Context::new(), 1, &[
+                opentelemetry::KeyValue::new("chain_id", chain_id),
+            ]);
     }
 }


### PR DESCRIPTION
# Description

Adding metric there so we can see if websockets are used at all.
Relay had similar mem leak problem, and the team tracked it down to tungstenite. 
This will confirm if it's worth to go down that road

Resolves #238 

## How Has This Been Tested?

test ran

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
