### PR TITLE
chore: handle more errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -58,8 +58,11 @@ pub enum RpcError {
     #[error("Invalid address")]
     IdentityInvalidAddress,
 
-    #[error("Ethers provider error: {0}")]
-    EthersProviderError(ethers::providers::ProviderError),
+    #[error("Name lookup error: {0}")]
+    NameLookup(ethers::providers::ProviderError),
+
+    #[error("Avatar lookup error: {0}")]
+    AvatarLookup(ethers::providers::ProviderError),
 }
 
 impl IntoResponse for RpcError {

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -192,10 +192,21 @@ async fn lookup_identity_rpc(
                 |e| match e {
                     ProviderError::EnsError(_) | ProviderError::EnsNotOwned(_) => Ok(None),
                     ProviderError::CustomError(e) if &e == "Unsupported ERC token type" => {
-                        // This is a problem with how the avatar was configured by the user.
-                        // Originates from here:
-                        // - https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/ext/erc.rs#L34
-                        // - https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/rpc/provider.rs#L818
+                        // Problem with how the avatar was configured by the user
+                        // https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/ext/erc.rs#L34
+                        // https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/rpc/provider.rs#L818
+                        Ok(None)
+                    }
+                    ProviderError::CustomError(e) if &e == "Incorrect owner." => {
+                        // NFT avatar not owned by same owner
+                        // https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/rpc/provider.rs#L830C31-L830C31
+                        Ok(None)
+                    }
+                    ProviderError::CustomError(e)
+                        if e.starts_with("Invalid metadata url: relative URL without a base") =>
+                    {
+                        // Problem with resolving NFT avatar
+                        // https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/rpc/provider.rs#L877
                         Ok(None)
                     }
                     ProviderError::CustomError(e)

--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -192,11 +192,12 @@ async fn lookup_identity_rpc(
                 |e| match e {
                     ProviderError::EnsError(_) | ProviderError::EnsNotOwned(_) => Ok(None),
                     ProviderError::CustomError(e) if &e == "Unsupported ERC token type" => {
-                        // This is a problem with how the avatar was configured by the user. Originates from here:
-                        // https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/ext/erc.rs#L34
-                        // https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/rpc/provider.rs#L818
+                        // This is a problem with how the avatar was configured by the user.
+                        // Originates from here:
+                        // - https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/ext/erc.rs#L34
+                        // - https://github.com/gakonst/ethers-rs/blob/f9c72f222cbf82219101c8772cfa49ba4205ef1d/ethers-providers/src/rpc/provider.rs#L818
                         Ok(None)
-                    },
+                    }
                     ProviderError::CustomError(e)
                         if e.starts_with("relative URL without a base") =>
                     {


### PR DESCRIPTION
# Description

Fix couple of errors that I'm seeing in CloudWatch logs.

This also explicitly prefixes RpcErrors to make it easier to identity problems coming from the rpc-proxy later in the future.

Also identify if error comes from name or avatar lookup.

Resolves #250 

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
