### PR TITLE
chore: only POST for RPC

### DIFF
--- a/src/handlers/identity.rs
+++ b/src/handlers/identity.rs
@@ -2,7 +2,6 @@ use {
     super::HANDLER_TASK_METRICS,
     crate::{
         error::RpcError,
-        extractors::method::Method,
         handlers::RpcQueryParams,
         json_rpc::{JsonRpcError, JsonRpcResponse},
         state::AppState,
@@ -19,7 +18,7 @@ use {
         providers::{JsonRpcClient, Middleware, Provider, ProviderError},
         types::H160,
     },
-    hyper::{body::to_bytes, HeaderMap, Method as HyperMethod, StatusCode},
+    hyper::{body::to_bytes, HeaderMap, StatusCode},
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{
         net::SocketAddr,
@@ -333,7 +332,6 @@ impl JsonRpcClient for SelfProvider {
             self.state.clone(),
             self.connect_info,
             self.query.clone(),
-            Method(HyperMethod::POST),
             self.path.clone(),
             self.headers.clone(),
             serde_json::to_vec(&JsonRpcRequest {

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -43,18 +43,10 @@ async fn handler_internal(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Query(query_params): Query<RpcQueryParams>,
     Method(method): Method,
-    path: MatchedPath,
+    _path: MatchedPath,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, RpcError> {
-    if method != hyper::Method::POST {
-        warn!(
-            "Handling non-POST method: chain_id:{}, project_id:{}, method:{method}, \
-             path:{path:?}, body:{body:?}",
-            query_params.chain_id, query_params.project_id
-        );
-    }
-
     let project = state
         .registry
         .project_data(&query_params.project_id)

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -1,12 +1,6 @@
 use {
     super::HANDLER_TASK_METRICS,
-    crate::{
-        analytics::MessageInfo,
-        error::RpcError,
-        extractors::method::Method,
-        handlers::RpcQueryParams,
-        state::AppState,
-    },
+    crate::{analytics::MessageInfo, error::RpcError, handlers::RpcQueryParams, state::AppState},
     axum::{
         body::Bytes,
         extract::{ConnectInfo, MatchedPath, Query, State},
@@ -28,12 +22,11 @@ pub async fn handler(
     state: State<Arc<AppState>>,
     addr: ConnectInfo<SocketAddr>,
     query_params: Query<RpcQueryParams>,
-    method: Method,
     path: MatchedPath,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, RpcError> {
-    handler_internal(state, addr, query_params, method, path, headers, body)
+    handler_internal(state, addr, query_params, path, headers, body)
         .with_metrics(HANDLER_TASK_METRICS.with_name("proxy"))
         .await
 }
@@ -42,7 +35,6 @@ async fn handler_internal(
     State(state): State<Arc<AppState>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Query(query_params): Query<RpcQueryParams>,
-    Method(method): Method,
     _path: MatchedPath,
     headers: HeaderMap,
     body: Bytes,
@@ -99,7 +91,7 @@ async fn handler_internal(
     // Start timing external provider added time
     let external_call_start = SystemTime::now();
 
-    let mut response = provider.proxy(&chain_id, method, body).await.tap_err(|e| {
+    let mut response = provider.proxy(&chain_id, body).await.tap_err(|e| {
         warn!(
             "Failed call to provider: {} with {}",
             provider.provider_kind(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use {
     anyhow::Context,
     axum::{
         response::Response,
-        routing::{any, get},
+        routing::{get, post},
         Router,
     },
     env::{
@@ -132,8 +132,8 @@ pub async fn bootstrap(config: Config) -> RpcResult<()> {
     ));
 
     let app = Router::new()
-        .route("/v1", any(handlers::proxy::handler))
-        .route("/v1/", any(handlers::proxy::handler))
+        .route("/v1", post(handlers::proxy::handler))
+        .route("/v1/", post(handlers::proxy::handler))
         .route("/ws", get(handlers::ws_proxy::handler))
         .route("/v1/identity/:address", get(handlers::identity::handler))
         .route_layer(proxy_metrics)

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
 };
@@ -43,19 +43,14 @@ impl RateLimited for BinanceProvider {
 
 #[async_trait]
 impl RpcProvider for BinanceProvider {
-    async fn proxy(
-        &self,
-        chain_id: &str,
-        method: hyper::http::Method,
-        body: hyper::body::Bytes,
-    ) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
         let hyper_request = hyper::http::Request::builder()
-            .method(method)
+            .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -17,7 +17,7 @@ use {
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
     axum_tungstenite::WebSocketUpgrade,
-    hyper::{client::HttpConnector, http, Client},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
     wc::future::FutureExt,
@@ -111,12 +111,7 @@ impl RateLimited for InfuraProvider {
 
 #[async_trait]
 impl RpcProvider for InfuraProvider {
-    async fn proxy(
-        &self,
-        chain_id: &str,
-        method: hyper::http::Method,
-        body: hyper::body::Bytes,
-    ) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
             .get(chain_id)
@@ -125,7 +120,7 @@ impl RpcProvider for InfuraProvider {
         let uri = format!("https://{}.infura.io/v3/{}", chain, self.project_id);
 
         let hyper_request = hyper::http::Request::builder()
-            .method(method)
+            .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -239,12 +239,7 @@ impl ProviderKind {
 
 #[async_trait]
 pub trait RpcProvider: Provider {
-    async fn proxy(
-        &self,
-        chain_id: &str,
-        method: hyper::http::Method,
-        body: hyper::body::Bytes,
-    ) -> RpcResult<Response>;
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response>;
 }
 
 pub trait RpcProviderFactory<T: ProviderConfig>: Provider {

--- a/src/providers/omnia.rs
+++ b/src/providers/omnia.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, Client, StatusCode},
+    hyper::{client::HttpConnector, Client, Method, StatusCode},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
 };
@@ -43,12 +43,7 @@ impl RateLimited for OmniatechProvider {
 
 #[async_trait]
 impl RpcProvider for OmniatechProvider {
-    async fn proxy(
-        &self,
-        chain_id: &str,
-        method: hyper::http::Method,
-        body: hyper::body::Bytes,
-    ) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let chain = self
             .supported_chains
             .get(chain_id)
@@ -57,7 +52,7 @@ impl RpcProvider for OmniatechProvider {
         let uri = format!("https://endpoints.omniatech.io/v1/{}/mainnet/public", chain);
 
         let hyper_request = hyper::http::Request::builder()
-            .method(method)
+            .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;

--- a/src/providers/pokt.rs
+++ b/src/providers/pokt.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{self, client::HttpConnector, Client},
+    hyper::{self, client::HttpConnector, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
 };
@@ -65,12 +65,7 @@ impl RateLimited for PoktProvider {
 
 #[async_trait]
 impl RpcProvider for PoktProvider {
-    async fn proxy(
-        &self,
-        chain_id: &str,
-        method: hyper::http::Method,
-        body: hyper::body::Bytes,
-    ) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
             .get(chain_id)
@@ -82,7 +77,7 @@ impl RpcProvider for PoktProvider {
         );
 
         let hyper_request = hyper::http::Request::builder()
-            .method(method)
+            .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;

--- a/src/providers/publicnode.rs
+++ b/src/providers/publicnode.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
 };
@@ -40,12 +40,7 @@ impl RateLimited for PublicnodeProvider {
 
 #[async_trait]
 impl RpcProvider for PublicnodeProvider {
-    async fn proxy(
-        &self,
-        chain_id: &str,
-        method: hyper::http::Method,
-        body: hyper::body::Bytes,
-    ) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let chain = &self
             .supported_chains
             .get(chain_id)
@@ -54,7 +49,7 @@ impl RpcProvider for PublicnodeProvider {
         let uri = format!("https://{}.publicnode.com", chain);
 
         let hyper_request = hyper::http::Request::builder()
-            .method(method)
+            .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;

--- a/src/providers/zksync.rs
+++ b/src/providers/zksync.rs
@@ -6,7 +6,7 @@ use {
     },
     async_trait::async_trait,
     axum::response::{IntoResponse, Response},
-    hyper::{client::HttpConnector, http, Client},
+    hyper::{client::HttpConnector, http, Client, Method},
     hyper_tls::HttpsConnector,
     std::collections::HashMap,
 };
@@ -40,19 +40,14 @@ impl RateLimited for ZKSyncProvider {
 
 #[async_trait]
 impl RpcProvider for ZKSyncProvider {
-    async fn proxy(
-        &self,
-        chain_id: &str,
-        method: hyper::http::Method,
-        body: hyper::body::Bytes,
-    ) -> RpcResult<Response> {
+    async fn proxy(&self, chain_id: &str, body: hyper::body::Bytes) -> RpcResult<Response> {
         let uri = self
             .supported_chains
             .get(chain_id)
             .ok_or(RpcError::ChainNotFound)?;
 
         let hyper_request = hyper::http::Request::builder()
-            .method(method)
+            .method(Method::POST)
             .uri(uri)
             .header("Content-Type", "application/json")
             .body(hyper::body::Body::from(body))?;


### PR DESCRIPTION
# Description

Only allow POSTing on RPC endpoints (`/v1` and `/v1/`). Non-POST requests are not used for any legitimate traffic as determined [here](https://walletconnect.slack.com/archives/C03SCF66K2T/p1689286049171369?thread_ts=1687284476.715569&cid=C03SCF66K2T) and potentially impact our own rate limits/quotas.

Resolves #266 

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
