### PR TITLE
chore: decrease service executor timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ export RPC_PROXY_STORAGE_IDENTITY_CACHE_REDIS_ADDR_WRITE="redis://localhost:6379
 
 export TEST_RPC_PROXY_PROJECT_ID=""
 
+# Secret to use to execute memory profiling
+export RPC_PROXY_DEBUG_SECRET="secret"
+
 export RPC_PROXY_INFURA_PROJECT_ID=""
 export RPC_PROXY_POKT_PROJECT_ID=""
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ use {
     wc::{http::ServiceTaskExecutor, metrics::ServiceMetrics},
 };
 
-const SERVICE_TASK_TIMEOUT: Duration = Duration::from_secs(300);
+const SERVICE_TASK_TIMEOUT: Duration = Duration::from_secs(15);
 const KEEPALIVE_IDLE_DURATION: Duration = Duration::from_secs(5);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 const KEEPALIVE_RETRIES: u32 = 1;


### PR DESCRIPTION
# Description

Decreases the service executor timeout to terminate connections after 15 seconds.

Resolves #272 

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
