### PR TITLE
chore: identity lookup analytics export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,6 +3669,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_piecewise_default",
+ "sha256",
  "tap",
  "test-context",
  "thiserror",
@@ -4066,6 +4067,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.6",
+]
+
+[[package]]
+name = "sha256"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "386f700b0c798d92ac20a53342c240ff9d58030c3b845fbaeb92eead3a774792"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "hex",
+ "sha2 0.10.6",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ prometheus-http-query = "0.6.6"
 ethers = { version = "2.0.7", git = "https://github.com/gakonst/ethers-rs" } # using Git version because crates.io version fails clippy
 
 bytes = "1.4.0"
+sha256 = "1.2.2"
 
 [dev-dependencies]
 jsonrpc = "0.14.0"

--- a/src/analytics/identity_lookup_info.rs
+++ b/src/analytics/identity_lookup_info.rs
@@ -1,0 +1,63 @@
+use {
+    crate::handlers::{identity::IdentityLookupSource, RpcQueryParams},
+    ethers::types::H160,
+    parquet_derive::ParquetRecordWriter,
+    serde::Serialize,
+    std::{sync::Arc, time::Duration},
+};
+
+#[derive(Debug, Clone, Serialize, ParquetRecordWriter)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityLookupInfo {
+    pub timestamp: chrono::NaiveDateTime,
+
+    pub address_hash: String,
+    pub name_present: bool,
+    pub avatar_present: bool,
+    pub source: String,
+    pub latency_secs: f64,
+
+    pub project_id: String,
+    pub chain_id: String,
+
+    pub origin: Option<String>,
+
+    pub region: Option<String>,
+    pub country: Option<Arc<str>>,
+    pub continent: Option<Arc<str>>,
+}
+
+impl IdentityLookupInfo {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        query_params: &RpcQueryParams,
+        address: H160,
+        name_present: bool,
+        avatar_present: bool,
+        source: IdentityLookupSource,
+        latency: Duration,
+        origin: Option<String>,
+        region: Option<Vec<String>>,
+        country: Option<Arc<str>>,
+        continent: Option<Arc<str>>,
+    ) -> Self {
+        Self {
+            timestamp: gorgon::time::now(),
+
+            address_hash: sha256::digest(address.as_ref()),
+            name_present,
+            avatar_present,
+            source: source.as_str().to_string(),
+            latency_secs: latency.as_secs_f64(),
+
+            project_id: query_params.project_id.to_owned(),
+            chain_id: query_params.chain_id.to_lowercase(),
+
+            origin,
+
+            region: region.map(|r| r.join(", ")),
+            country,
+            continent,
+        }
+    }
+}

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -83,7 +83,7 @@ async fn handler_internal(
             continent,
             &provider.provider_kind(),
             origin,
-        ))
+        ));
     }
 
     let project_id = query_params.project_id.clone();

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -284,13 +284,10 @@ impl Metrics {
             )]);
     }
 
-    pub fn add_identity_lookup_latency(&self, start: SystemTime, source: &IdentityLookupSource) {
+    pub fn add_identity_lookup_latency(&self, latency: Duration, source: &IdentityLookupSource) {
         self.identity_lookup_latency_tracker.record(
             &otel::Context::new(),
-            start
-                .elapsed()
-                .unwrap_or(Duration::from_secs(0))
-                .as_secs_f64(),
+            latency.as_secs_f64(),
             &[otel::KeyValue::new("source", source.as_str())],
         );
     }


### PR DESCRIPTION
# Description

Exports analytics for identity lookups. Data includes:
- SHA256 hash of the address
- If the resolved identity contained a name or avatar
- If the identity was pulled from cache or if it needed to perform an RPC call
- The total latency of the request
- Origin
- Project ID
- Chain ID
- geo information

Resolves #276

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
