### PR TITLE
chore: handle invalid formatted project IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "cerberus"
 version = "0.2.0"
-source = "git+https://github.com/WalletConnect/cerberus.git?tag=v0.1.2#835a7178d7d7a7ea5e3b521163586fb072cd7e1d"
+source = "git+https://github.com/WalletConnect/cerberus.git?tag=v0.9.1#e35d31285bcf89e1809192b3a0fe0406f9f40e22"
 dependencies = [
  "async-trait",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ pnet_datalink = "0.31"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "ansi"] }
 
-cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.1.2" }
+cerberus = { git = "https://github.com/WalletConnect/cerberus.git", tag = "v0.9.1" }
 parquet = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "99a1cc3", default-features = false, features = ["flate2"] }
 parquet_derive = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "99a1cc3" }
 gorgon = { git = "https://github.com/WalletConnect/gorgon.git", tag = "v0.5.2" }


### PR DESCRIPTION
# Description

Bumps the cerberus version to include this fix: https://github.com/WalletConnect/cerberus/pull/20

Resolves #278

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
