### PR TITLE
docs: add supported chains list

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -1,0 +1,36 @@
+# List of supported chains
+
+## HTTP RPC
+
+- Ethereum
+- Ethereum Goerli
+- Optimism
+- Optimism Kovan
+- Optimism Goerli
+- Arbitrum
+- Arbitrum Goerli
+- Polygon
+- Polygon Mumbai
+- Celo Mainnet
+- Aurora
+- Aurora Testnet
+- Binance Smart Chain
+- Binance Smart Chain Testnet
+- Avalanche C-Chain
+- Avalanche Fuji Testnet
+- Near
+- Gnosis Chain
+- Solana
+
+## Websocket RPC
+
+- Ethereum
+- Ethereum Goerli
+- Optimism
+- Optimism Kovan
+- Optimism Goerli
+- Arbitrum
+- Arbitrum Goerli
+- Celo
+- Aurora
+- Aurora Testnet

--- a/src/env/binance.rs
+++ b/src/env/binance.rs
@@ -28,6 +28,8 @@ impl Default for BinanceConfig {
 }
 
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
     HashMap::from([
         // Binance Smart Chain Mainnet
         (

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -34,6 +34,8 @@ impl ProviderConfig for InfuraConfig {
 }
 
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
     HashMap::from([
         // Ethereum
         (
@@ -123,6 +125,8 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
 }
 
 fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
     HashMap::from([
         // Ethereum
         (

--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -28,6 +28,8 @@ impl ProviderConfig for OmniatechConfig {
 }
 
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
     HashMap::from([
         // Ethereum mainnet
         (

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -31,6 +31,8 @@ impl ProviderConfig for PoktConfig {
 }
 
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
     HashMap::from([
         // Solana Mainnet
         (

--- a/src/env/publicnode.rs
+++ b/src/env/publicnode.rs
@@ -28,6 +28,8 @@ impl ProviderConfig for PublicnodeConfig {
 }
 
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
     HashMap::from([
         // Ethereum mainnet
         (

--- a/src/env/zksync.rs
+++ b/src/env/zksync.rs
@@ -28,6 +28,8 @@ impl ProviderConfig for ZKSyncConfig {
 }
 
 fn default_supported_chains() -> HashMap<String, (String, Weight)> {
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
     HashMap::from([
         // zkSync Testnet
         (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,8 @@ fn init_providers() -> ProviderRepository {
     let infura_project_id = std::env::var("RPC_PROXY_INFURA_PROJECT_ID")
         .expect("Missing RPC_PROXY_INFURA_PROJECT_ID env var");
 
+    // Keep in-sync with SUPPORTED_CHAINS.md
+
     providers.add_provider::<PoktProvider, PoktConfig>(PoktConfig::new(
         std::env::var("RPC_PROXY_POKT_PROJECT_ID")
             .expect("Missing RPC_PROXY_POKT_PROJECT_ID env var"),


### PR DESCRIPTION
# Description

Adds a public list of supported chains and the intention of keeping this up-to-date.

Resolves #281

This is a manual process for now. In the future if we get SLAs it would be desirable and easy to automate this process so we make sure it's correct and don't accidentally remove chain support. I experimented with an automated process on [this](https://github.com/WalletConnect/rpc-proxy/blob/feat/abandoned-automated-chain-list/src/bin/generate-chain-list.rs) branch. Idea is to run this script to generate the Markdown file which would pull from [ethereum-lists/chains](https://github.com/ethereum-lists/chains) to get the chain name. We would also run it in CI to make sure it is correct. Reason I didn't continue with this approach was:
- Some chains were named weird e.g. Mumbai instead of Polygon Mumbai or Goerli instead of Ethereum Goerli or Gnosis instead of Gnosis Chain.
- It had some inconvenient ordering problems due to the use of a HashSet to deduplicate (e.g. not sorted by popularity or grouped testnets together with mainnets)
- Didn't account for a potential desire to hide support for some chains.
- Didn't yet work for non- EIP-115 chains (Solana and Near) which would be a hardcoded case.

But the above issues could be easily fixed I'm sure.

## How Has This Been Tested?

N/A

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
