### PR TITLE
feat: Ethereum Sepolia & update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# rpc-proxy
+# Blockchain API
+
+WalletConnect's Blockchain API. We do not run our own RPC nodes but instead proxy to and load balance across other popular RPC providers.
+
+## Usage
+
+Endpoint: `https://rpc.walletconnecct.com/v1?chainId=eip155:1&projectId=<your-project-id>`
+
+Obtain a `projectId` from <https://cloud.walletconnect.com>
+
+See [SUPPORTED_CHAINS.md](./SUPPORTED_CHAINS.md) for which chains we support and which `chainId` to use.
+
+## Development
 
 `cargo run` to run and then `curl -v localhost:3000/health` or `curl -X POST -H "Content-Type:application/json" "http://localhost:3000/v1?chainId=eip155:5&projectId=someid" -d '{"id":"1660887896683","jsonrpc":"2.0","method":"eth_chainId","params":[]}'`
 

--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -1,36 +1,37 @@
 # List of supported chains
 
+Chain name with associated `chainId` query param to use.
+
 ## HTTP RPC
 
-- Ethereum
-- Ethereum Goerli
-- Ethereum Sepolia
-- Optimism
-- Optimism Goerli
-- Arbitrum
-- Arbitrum Goerli
-- Polygon
-- Polygon Mumbai
-- Celo Mainnet
-- Aurora
-- Aurora Testnet
-- Binance Smart Chain
-- Binance Smart Chain Testnet
-- Avalanche C-Chain
-- Avalanche Fuji Testnet
-- Near
-- Gnosis Chain
-- Solana
+- Ethereum (`eip115:1`)
+- Ethereum Goerli (`eip155:5`)
+- Ethereum Sepolia (`eip155:11155111`)
+- Optimism (`eip155:10`)
+- Optimism Goerli (`eip155:420`)
+- Arbitrum (`eip155:42161`)
+- Arbitrum Goerli (`eip155:421613`)
+- Polygon (`eip155:137`)
+- Polygon Mumbai (`eip155:80001`)
+- Celo Mainnet (`eip155:42220`)
+- Aurora (`eip155:1313161554`)
+- Aurora Testnet (`eip155:1313161555`)
+- Binance Smart Chain (`eip155:56`)
+- Binance Smart Chain Testnet (`eip155:56`)
+- Avalanche C-Chain (`eip155:43114`)
+- Avalanche Fuji Testnet (`eip155:43113`)
+- Near (`near`)
+- Gnosis Chain (`eip155:100`)
+- Solana (`solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz` or `solana-mainnet`)
 
 ## Websocket RPC
 
-- Ethereum
-- Ethereum Goerli
-- Ethereum Sepolia
-- Optimism
-- Optimism Goerli
-- Arbitrum
-- Arbitrum Goerli
-- Celo
-- Aurora
-- Aurora Testnet
+- Ethereum (`eip115:1`)
+- Ethereum Goerli (`eip155:5`)
+- Ethereum Sepolia (`eip155:11155111`)
+- Optimism (`eip155:10`)
+- Optimism Goerli (`eip155:420`)
+- Arbitrum (`eip155:42161`)
+- Arbitrum Goerli (`eip155:421613`)
+- Aurora (`eip155:1313161554`)
+- Aurora Testnet (`eip155:1313161555`)

--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -4,8 +4,8 @@
 
 - Ethereum
 - Ethereum Goerli
+- Ethereum Sepolia
 - Optimism
-- Optimism Kovan
 - Optimism Goerli
 - Arbitrum
 - Arbitrum Goerli
@@ -26,8 +26,8 @@
 
 - Ethereum
 - Ethereum Goerli
+- Ethereum Sepolia
 - Optimism
-- Optimism Kovan
 - Optimism Goerli
 - Arbitrum
 - Arbitrum Goerli

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -59,13 +59,6 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         (
-            "eip155:69".into(),
-            (
-                "optimism-kovan".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
-        (
             "eip155:420".into(),
             (
                 "optimism-goerli".into(),
@@ -154,13 +147,6 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
             ),
         ),
         (
-            "eip155:69".into(),
-            (
-                "optimism-kovan".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
-        (
             "eip155:420".into(),
             (
                 "optimism-goerli".into(),
@@ -184,7 +170,7 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
         ),
         // Celo
         (
-            "eip155:42220".into(),
+            "eip155:42220".into(), // failed on testing
             (
                 "celo-mainnet".into(),
                 Weight::new(Priority::Normal).unwrap(),

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -46,6 +46,10 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:5".into(),
             ("goerli".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        (
+            "eip155:11155111".into(),
+            ("sepolia".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Optimism
         (
             "eip155:10".into(),
@@ -136,6 +140,10 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
         (
             "eip155:5".into(),
             ("goerli".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
+        (
+            "eip155:11155111".into(),
+            ("sepolia".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Optimism
         (

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -168,14 +168,6 @@ fn default_ws_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
-        // Celo
-        (
-            "eip155:42220".into(), // failed on testing
-            (
-                "celo-mainnet".into(),
-                Weight::new(Priority::Normal).unwrap(),
-            ),
-        ),
         // Aurora
         (
             "eip155:1313161554".into(),

--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -63,7 +63,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         ),
         // Solana
         (
-            "solana-mainnet".into(),
+            "solana-mainnet".into(), // consider changing to `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz` like Pokt provider
             ("sol".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Avalanche C chain

--- a/src/env/omnia.rs
+++ b/src/env/omnia.rs
@@ -63,7 +63,9 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
         ),
         // Solana
         (
-            "solana-mainnet".into(), // consider changing to `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz` like Pokt provider
+            // TODO: consider changing from `solana-mainnet` to
+            // `solana:4sgjmw1sunhzsxgspuhpqldx6wiyjntz` like Pokt provider
+            "solana-mainnet".into(),
             ("sol".into(), Weight::new(Priority::Normal).unwrap()),
         ),
         // Avalanche C chain

--- a/src/env/pokt.rs
+++ b/src/env/pokt.rs
@@ -72,6 +72,10 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:5".into(),
             ("eth-goerli".into(), Weight::new(Priority::Normal).unwrap()),
         ),
+        (
+            "eip155:11155111".into(),
+            ("sepolia".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
         // Optimism
         (
             "eip155:10".into(),


### PR DESCRIPTION
# Description

- Add support for Ethereum Sepolia via Infura and Pokt
- Update README to be more public-facing
- Remove support for Optimism Kovan as this network was decommissioned last year and my curl and websocket tests demonstrate this
- Remove Celo Websocket as this didn't work with my test (see JS commands below)

```
% curl -X POST https://optimism-kovan.infura.io/v3/<infura-key> --data '{"id":"1660887896683","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
{
  "id":null,
  "error": {
    "code":-32601,
    "message":"Network decommissioned, please use Goerli",
    "data": {
      "see":"https://blog.infura.io/post/deprecation-timeline-for-rinkeby-ropsten-and-kovan-testnets"
    }
  }
}
```

- All networks via WebSocket except the 3 Ethereum ones are actually unofficially supported by Infura. Their dashboard says not supported, but WS RPC calls go through. It may be a good idea to remove these as they are unsupported, but not doing that in this PR. Tested with:

```javascript
ws = new WebSocket("wss://celo-mainnet.infura.io/ws/v3/<infura-key>");
ws.addEventListener("open", () => {
  ws.addEventListener("message", message => console.log(message.data));
  ws.send('{"id":"1660887896683","jsonrpc":"2.0","method":"eth_chainId","params":[]}');
});
```

Resolves #283 #287 

## How Has This Been Tested?

Locally

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
