### PR TITLE
chore: remove debug_secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,5 @@ export TF_VAR_infura_project_id=""
 export TF_VAR_pokt_project_id=""
 export TF_VAR_grafana_endpoint=$(aws grafana list-workspaces | jq -r '.workspaces[] | select( .tags.Env == "prod") | select( .tags.Name == "grafana-9") | .endpoint')
 export TF_VAR_registry_api_auth_token=""
-export TF_VAR_debug_secret=""
 
 export GRAFANA_AUTH="Grab one at https://$TF_VAR_grafana_endpoint"

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,8 +1,8 @@
 use {
     crate::{
         analytics::Config as AnalyticsConfig,
-        debug::DebugConfig,
         error,
+        profiler::ProfilerConfig,
         project::{storage::Config as StorageConfig, Config as RegistryConfig},
         providers::{ProviderKind, Weight},
     },
@@ -35,7 +35,7 @@ pub struct Config {
     pub registry: RegistryConfig,
     pub storage: StorageConfig,
     pub analytics: AnalyticsConfig,
-    pub debug: DebugConfig,
+    pub profiler: ProfilerConfig,
 }
 
 impl Config {
@@ -45,7 +45,7 @@ impl Config {
             registry: from_env("RPC_PROXY_REGISTRY_")?,
             storage: from_env("RPC_PROXY_STORAGE_")?,
             analytics: from_env("RPC_PROXY_ANALYTICS_")?,
-            debug: from_env("RPC_PROXY_DEBUG_")?,
+            profiler: from_env("RPC_PROXY_PROFILER_")?,
         })
     }
 }

--- a/src/profiler/mod.rs
+++ b/src/profiler/mod.rs
@@ -1,9 +1,7 @@
 #[derive(Debug, Clone, serde::Deserialize)]
-pub struct DebugConfig {
-    pub secret: String,
-}
+pub struct ProfilerConfig {}
 
-pub async fn debug_metrics() {
+pub async fn run() {
     loop {
         if let Err(err) = wc::alloc::stats::update_jemalloc_metrics() {
             tracing::warn!(?err, "failed to collect jemalloc stats");

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -87,8 +87,6 @@ resource "aws_ecs_task_definition" "app_task" {
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_BUCKET", "value" : var.analytics_geoip_db_bucket_name },
         { "name" : "RPC_PROXY_ANALYTICS_GEOIP_DB_KEY", "value" : var.analytics_geoip_db_key },
 
-        { "name" : "RPC_PROXY_DEBUG_SECRET", "value" : var.debug_secret },
-
         { "name" : "SIG_PROXY_URL", "value" : "http://127.0.0.1:8080/workspaces/${var.prometheus_workspace_id}" },
         { "name" : "SIG_PROM_WORKSPACE_HEADER", "value" : "aps-workspaces.${var.region}.amazonaws.com" },
       ],

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -144,8 +144,3 @@ variable "analytics_geoip_db_bucket_name" {
   description = "The name of the bucket containing the GeoIP database"
   type        = string
 }
-
-variable "debug_secret" {
-  description = "The secret used to run profiler endpoint"
-  type        = string
-}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -116,8 +116,6 @@ module "ecs" {
   analytics_data_lake_bucket_name = local.analytics_data_lake_bucket_name
   analytics_data_lake_kms_key_arn = var.analytics_data_lake_kms_key_arn
   analytics_geoip_db_bucket_name  = local.analytics_geoip_db_bucket_name
-
-  debug_secret = var.debug_secret
 }
 
 module "redis" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,8 +51,3 @@ variable "analytics_data_lake_kms_key_arn" {
   description = "The ARN of KMS encryption key for the data-lake bucket."
   type        = string
 }
-
-variable "debug_secret" {
-  description = "The secret used to run memory profile endpoint."
-  type        = string
-}


### PR DESCRIPTION
# Description

DEBUG_SECRET is no longer used as of https://github.com/WalletConnect/rpc-proxy/pull/249. Removing it now

Resolves #288 

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
