### PR TITLE
fix: Infura supported chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ WalletConnect's Blockchain API. We do not run our own RPC nodes but instead prox
 
 ## Usage
 
-Endpoint: `https://rpc.walletconnecct.com/v1?chainId=eip155:1&projectId=<your-project-id>`
+Endpoint: `https://rpc.walletconnect.com/v1?chainId=eip155:1&projectId=<your-project-id>`
+
+For example:
+
+```bash
+curl -X POST "https://rpc.walletconnect.com/v1?chainId=eip155:1&projectId=<your-project-id>" --data '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
+```
 
 Obtain a `projectId` from <https://cloud.walletconnect.com>
 
@@ -22,7 +28,8 @@ just run
 ```
 
 ```bash
-curl -X POST "http://localhost:3000/v1?chainId=eip155:5&projectId=someid" -d '{"id":"1660887896683","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
+# projectId is not validated under default .env.example configuration
+curl -X POST "http://localhost:3000/v1?chainId=eip155:1&projectId=someid" --data '{"id":"1","jsonrpc":"2.0","method":"eth_chainId","params":[]}'
 ```
 
 ## Testing

--- a/src/providers/infura.rs
+++ b/src/providers/infura.rs
@@ -135,7 +135,7 @@ impl RpcProviderFactory<InfuraConfig> for InfuraProvider {
     fn new(provider_config: &InfuraConfig) -> Self {
         let forward_proxy_client = Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
         let supported_chains: HashMap<String, String> = provider_config
-            .supported_ws_chains
+            .supported_chains
             .iter()
             .map(|(k, v)| (k.clone(), v.0.clone()))
             .collect();
@@ -151,7 +151,7 @@ impl RpcProviderFactory<InfuraConfig> for InfuraProvider {
 impl RpcProviderFactory<InfuraConfig> for InfuraWsProvider {
     fn new(provider_config: &InfuraConfig) -> Self {
         let supported_chains: HashMap<String, String> = provider_config
-            .supported_chains
+            .supported_ws_chains
             .iter()
             .map(|(k, v)| (k.clone(), v.0.clone()))
             .collect();


### PR DESCRIPTION
# Description

🤦 I used the `supported_ws_providers` in the wrong place, so integration tests became flaky (as the "infura" tests don't actually test Infura exclusively), resulting in internal server errors from whatever provider was in-use. Luckily they never passed by chance in the number of times I retried the pipeline...

Resolves #297

## How Has This Been Tested?

Locally

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
