### PR TITLE
feat: log proxy errors

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -14,7 +14,10 @@ use {
         time::{Duration, SystemTime},
     },
     tap::TapFallible,
-    tracing::{info, log::warn, log::error},
+    tracing::{
+        info,
+        log::{error, warn},
+    },
     wc::future::FutureExt,
 };
 
@@ -123,7 +126,12 @@ async fn handler_internal(
             state.metrics.add_finished_provider_call(provider.borrow());
         }
         _ => {
-            error!("Call to provider '{}' failed with status '{}' and body '{:?}'", provider.provider_kind(), response.status(), response.body());
+            error!(
+                "Call to provider '{}' failed with status '{}' and body '{:?}'",
+                provider.provider_kind(),
+                response.status(),
+                response.body()
+            );
             state.metrics.add_failed_provider_call(provider.borrow());
         }
     };

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -14,7 +14,7 @@ use {
         time::{Duration, SystemTime},
     },
     tap::TapFallible,
-    tracing::{info, log::warn},
+    tracing::{info, log::warn, log::error},
     wc::future::FutureExt,
 };
 
@@ -123,6 +123,7 @@ async fn handler_internal(
             state.metrics.add_finished_provider_call(provider.borrow());
         }
         _ => {
+            error!("Call to provider '{}' failed with status '{}' and body '{:?}'", provider.provider_kind(), response.status(), response.body());
             state.metrics.add_failed_provider_call(provider.borrow());
         }
     };


### PR DESCRIPTION
# Description

Logs an `error` level log for failing providers plus the payload. This will help investigations such as lately when we wanted to investigate "non-provider errors" but weren't able to do so.

Closes #212 

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
