### PR TITLE
docs: disclaim WebSocket use

### DIFF
--- a/SUPPORTED_CHAINS.md
+++ b/SUPPORTED_CHAINS.md
@@ -30,6 +30,8 @@ Chain name with associated `chainId` query param to use.
 
 ## WebSocket RPC
 
+WebSocket RPC is not recommended for production use, and may be removed in the future.
+
 - Ethereum (`eip155:1`)
 - Ethereum Goerli (`eip155:5`)
 - Ethereum Sepolia (`eip155:11155111`)


### PR DESCRIPTION
# Description

WebSockets aren't implemented with as much care as HTTP RPC is. And it isn't clear if there are plans to improve this in the future.

- Only useful for watching events to avoid polling. Other performance/efficiency benefits can be already achieved with HTTP/2
- No load balancing/weighting during WebSocket sessions
  - Weights for WebSockets are never adjusted
  - No monitoring setup for WebSockets
- Not built with as much care as relay for handling many concurrent WebSockets
- Far fewer supported chains due to limited support from providers
- No 15-second forced disconnection for memory protection

Resolves #303

## How Has This Been Tested?

N/A

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
