### PR TITLE
feat: use Infura for Base Goerli

### DIFF
--- a/src/env/base.rs
+++ b/src/env/base.rs
@@ -48,7 +48,7 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
             "eip155:84531".into(),
             (
                 "https://goerli.base.org".into(),
-                Weight::new(Priority::Normal).unwrap(),
+                Weight::new(Priority::Low).unwrap(),
             ),
         ),
     ])

--- a/src/env/infura.rs
+++ b/src/env/infura.rs
@@ -122,6 +122,11 @@ fn default_supported_chains() -> HashMap<String, (String, Weight)> {
                 Weight::new(Priority::Normal).unwrap(),
             ),
         ),
+        // Base Goerli
+        (
+            "eip155:84531".into(),
+            ("base-goerli".into(), Weight::new(Priority::Normal).unwrap()),
+        ),
     ])
 }
 

--- a/tests/functional/http/infura.rs
+++ b/tests/functional/http/infura.rs
@@ -50,4 +50,7 @@ async fn infura_provider(ctx: &mut ServerContext) {
         "0x4e454153",
     )
     .await;
+
+    // Base Goerli
+    check_if_rpc_is_responding_correctly_for_supported_chain(ctx, "eip155:84531", "0x14a33").await
 }


### PR DESCRIPTION
# Description

Use Infura for Base Goerli and reduce priority of public RPC as it is rate limited.

Resolves #299 

## How Has This Been Tested?

Locally

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
