### PR TITLE
fix: Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG                 WORK_DIR="/app"
 FROM                ${base} AS chef
 
 WORKDIR             ${WORK_DIR} 
-RUN                 cargo install cargo-chef
+RUN                 cargo install cargo-chef --locked
 
 ################################################################################
 #


### PR DESCRIPTION
# Description

Docker build is failing because `cargo-chef` version isn't locked: https://github.com/WalletConnect/rpc-proxy/actions/runs/5967919903/job/16190688151

Docs say to lock this: https://github.com/LukeMathWalker/cargo-chef#how-to-install

Resolves #309

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
